### PR TITLE
DP-5994 - Retry query request after database restart

### DIFF
--- a/.jenkins/docker-compose-test.yml
+++ b/.jenkins/docker-compose-test.yml
@@ -20,7 +20,6 @@ services:
   tellus_db:
     image: amsterdam/postgres
     environment:
-    environment:
       POSTGRES_PASSWORD: insecure
       POSTGRES_USER: tellus
   monumenten_db:


### PR DESCRIPTION
Connections are stored in a LRU cache. But if the database is restarted in the meantime
the connection to that database is invalid. iThe query will fail and the connection is closed.
If the the query is retried a new connection will be created and the request will be succesfull

This is implemented as a decorator that catches the exception and handles the retries