### PR TITLE
Datasource registry

### DIFF
--- a/web/geosearch/datapunt_geosearch/datasource.py
+++ b/web/geosearch/datapunt_geosearch/datasource.py
@@ -1,7 +1,6 @@
 import logging
 import time
 import psycopg2.extras
-from flask import current_app
 
 from .config import DATAPUNT_API_URL
 from datapunt_geosearch.db import dbconnection
@@ -380,26 +379,11 @@ class MonumentenDataSource(DataSourceBase):
             }
 
 
-# Store mapping of dataset names to DataSource subclass for this dataset
-_datasets = None
-INITIALIZE_DELAY = 600  # 10 minutes
-_datasets_initialized = 0
-
 registry.register_dataset('DSN_BAG', BagDataSource)
 registry.register_dataset('DSN_NAP', NapMeetboutenDataSource)
 registry.register_dataset('DSN_MUNITIE', MunitieMilieuDataSource)
 registry.register_dataset('DSN_MUNITIE', BominslagMilieuDataSource)
 registry.register_dataset('DSN_MONUMENTEN', MonumentenDataSource)
-
-
-def _init_get_dataset_class(dsn=None):
-    global _datasets
-    global _datasets_initialized
-
-    # To avoid DDOS attacks do this only every INITIALIZE_DELAY at most
-    if _datasets is None or time.time() - _datasets_initialized > INITIALIZE_DELAY:
-        _datasets = registry.init_vsd_datasets(dsn=dsn)
-        _datasets_initialized = time.time()
 
 
 def get_dataset_class(ds_name, dsn=None):
@@ -411,16 +395,8 @@ def get_dataset_class(ds_name, dsn=None):
     :param dsn optional datasource name for reading catalog. Required for testing
     :return: subclass of DataSource for this dataset
     """
-    global _datasets
-
-    if _datasets is None or ds_name not in _datasets:
-        _init_get_dataset_class(dsn)
-
     return registry.get_by_name(ds_name)
 
 
 def get_all_dataset_names(dsn=None):
-    global _datasets
-    if _datasets is None:
-        _init_get_dataset_class(dsn)
     return registry.get_all_dataset_names()

--- a/web/geosearch/datapunt_geosearch/db.py
+++ b/web/geosearch/datapunt_geosearch/db.py
@@ -111,3 +111,10 @@ class _DBConnection:
                     cursor_factory=psycopg2.extras.RealDictCursor) as cur:
                 cur.execute(sql)
                 return cur.fetchall()
+
+    def fetch_one(self, sql):
+        with self._connection() as conn:
+            with conn.cursor(
+                    cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute(sql)
+                return cur.fetchone()

--- a/web/geosearch/datapunt_geosearch/db.py
+++ b/web/geosearch/datapunt_geosearch/db.py
@@ -1,0 +1,113 @@
+import contextlib
+import functools
+import logging
+
+import psycopg2.extras
+from psycopg2 import Error as Psycopg2Error
+
+
+_logger = logging.getLogger(__name__)
+
+
+def retry_on_psycopg2_error(func):
+    """
+    Decorator that retries 3 times after Postgres error, in particular if
+    the connection was not valid anymore because the database was restarted
+    """
+    @functools.wraps(func)
+    def wrapper_retry(*args, **kwargs):
+        retry = 3
+        while retry > 0:
+            try:
+                result = func(*args, **kwargs)
+            except Psycopg2Error:
+                if retry == 0:
+                    raise
+                else:
+                    retry -= 1
+                    _logger.warning(f'Retry query for {func.__name__} ({retry})')
+                    continue
+            break
+        return result
+    return wrapper_retry
+
+
+@functools.lru_cache()
+def dbconnection(dsn):
+    """Creates an instance of _DBConnection and remembers the last one made."""
+    return _DBConnection(dsn)
+
+
+class _DBConnection:
+    """ Wraps a PostgreSQL database connection that reports crashes and tries
+    its best to repair broken connections.
+
+    NOTE: doesn't always work, but the failure scenario is very hard to
+      reproduce. Also see https://github.com/psycopg/psycopg2/issues/263
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.conn_args = args
+        self.conn_kwargs = kwargs
+        self._conn = None
+        self._connect()
+
+    def _connect(self):
+        if self._conn is None:
+            self._conn = psycopg2.connect(*self.conn_args, **self.conn_kwargs)
+            self._conn.autocommit = True
+
+    def _is_usable(self):
+        """ Checks whether the connection is usable.
+
+        :returns boolean: True if we can query the database, False otherwise
+        """
+        try:
+            self._conn.cursor().execute("SELECT 1")
+        except psycopg2.Error:
+            return False
+        else:
+            return True
+
+    @contextlib.contextmanager
+    def _connection(self):
+        """ Contextmanager that catches tries to ensure we have a database
+        connection. Yields a Connection object.
+
+        If a :class:`psycopg2.DatabaseError` occurs then it will check whether
+        the connection is still usable, and if it's not, close and remove it.
+        """
+        try:
+            self._connect()
+            yield self._conn
+        except psycopg2.Error as e:
+            _logger.critical('AUTHZ DatabaseError: {}'.format(e))
+            if not self._is_usable():
+                with contextlib.suppress(psycopg2.Error):
+                    self._conn.close()
+                self._conn = None
+            raise e
+
+    @contextlib.contextmanager
+    def transaction_cursor(self, cursor_factory=None):
+        """ Yields a cursor with transaction.
+        """
+        with self._connection() as transaction:
+            with transaction:
+                with transaction.cursor(cursor_factory=cursor_factory) as cur:
+                    yield cur
+
+    @contextlib.contextmanager
+    def cursor(self, cursor_factory=None):
+        """ Yields a cursor without transaction.
+        """
+        with self._connection() as conn:
+            with conn.cursor(cursor_factory=cursor_factory) as cur:
+                yield cur
+
+    def fetch_dict(self, sql):
+        with self._connection() as conn:
+            with conn.cursor(
+                    cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute(sql)
+                return cur.fetchall()

--- a/web/geosearch/datapunt_geosearch/exceptions.py
+++ b/web/geosearch/datapunt_geosearch/exceptions.py
@@ -1,0 +1,2 @@
+class DataSourceException(Exception):
+    pass

--- a/web/geosearch/datapunt_geosearch/registry.py
+++ b/web/geosearch/datapunt_geosearch/registry.py
@@ -1,0 +1,120 @@
+from collections import defaultdict
+import logging
+import psycopg2.extras
+from flask import current_app
+from datapunt_geosearch.config import DATAPUNT_API_URL
+from datapunt_geosearch.db import dbconnection
+from datapunt_geosearch.exceptions import DataSourceException
+
+_logger = logging.getLogger(__name__)
+
+
+class DatasetRegistry:
+    """
+    Dataset Registry.
+    """
+
+    def __init__(self):
+        # Datasets is a dictionary of DSN => Datasets.
+        self.datasets = defaultdict(list)
+        self.providers = dict()
+        self.static_dataset_names = []
+        self._dso_datasets_initialized = None
+
+    def register_dataset(self, dsn_name, dataset_class):
+        self.datasets[dsn_name].append(dataset_class)
+
+        for item in dataset_class.metadata['datasets']['vsd'].keys():
+            self.providers[item] = dataset_class
+
+    def get_all_datasets(self):
+        return self.providers
+
+    def get_all_dataset_names(self):
+        return self.providers.keys()
+
+    def get_by_name(self, name):
+        return self.providers.get(name)
+
+    def init_dataset(self, row, class_name, dsn_name):
+        from datapunt_geosearch.datasource import DataSourceBase
+        if row['schema'] is None:
+            row['schema'] = 'public'
+        schema_table = row['schema'] + '.' + row['table_name']
+
+        if row['geometry_type'].upper() == 'POLYGON':
+            operator = 'contains'
+        else:
+            operator = 'within'
+        name = row['name']
+        name_field = row['name_field']
+        geometry_field = row['geometry_field']
+        id_field = row['id_field']
+
+        dataset_class = type(class_name, (DataSourceBase,), {
+            'metadata': {
+                'geofield': geometry_field,
+                'operator': operator,
+                'datasets': {
+                    'vsd': {
+                        name: schema_table,
+                    }
+                },
+                'fields': [
+                    f"{name_field} as display",
+                    f"cast('vsd/{name}' as varchar(30)) as type",
+                    f"'{DATAPUNT_API_URL}vsd/{name}/' || {id_field} || '/'  as uri",
+                    f"{geometry_field} as geometrie",
+                    f"{id_field} as id",
+                ],
+            },
+            'dsn_name': dsn_name
+        })
+
+        self.register_dataset(
+            dsn_name=dsn_name,
+            dataset_class=dataset_class
+        )
+        return dataset_class
+
+    def init_vsd_datasets(self, dsn=None):
+        if dsn is None:
+            dsn = current_app.config['DSN_VARIOUS_SMALL_DATASETS']
+        try:
+            dbconn = dbconnection(dsn)
+        except psycopg2.Error as e:
+            _logger.error('Error creating connection: %s' % e)
+            raise DataSourceException('error connecting to datasource') from e
+
+        sql = '''
+select *
+from cat_dataset
+where enable_geosearch = true
+        '''
+        datasets = dict()
+        for row in dbconn.fetch_dict(sql):
+            # Fetch primary key field. We need to know what the id is
+            if 'pk_field' in row:
+                row['id_field'] = row.pop('pk_field')
+            else:
+                sql_pk = '''
+select n data_type, db_column
+from cataset_fields
+where dat_id = %(ds_id)s and primary_key = true
+                '''
+                with dbconn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur1:
+                    cur1.execute(sql_pk, {'ds_id': row['id']})
+                    pk_row = cur1.fetchone()
+                    id_field = pk_row['db_column']
+
+                    row['id_field'] = id_field
+
+            datasets[row['name']] = self.init_dataset(
+                row=row,
+                class_name=row['name'].upper() + 'GenAPIDataSource',
+                dsn_name='DSN_VARIOUS_SMALL_DATASETS')
+
+        return datasets
+
+
+registry = DatasetRegistry()

--- a/web/geosearch/tests/test_dataset_registry.py
+++ b/web/geosearch/tests/test_dataset_registry.py
@@ -1,8 +1,11 @@
+import time
 import unittest
+import unittest.mock
 
 from datapunt_geosearch import config
 from datapunt_geosearch import datasource
-from datapunt_geosearch.registry import registry
+from datapunt_geosearch.db import dbconnection
+from datapunt_geosearch.registry import registry, DatasetRegistry
 
 
 class TestDatasetRegistry(unittest.TestCase):
@@ -10,6 +13,117 @@ class TestDatasetRegistry(unittest.TestCase):
         ds_class = datasource.get_dataset_class('biz', dsn=config.DSN_VARIOUS_SMALL_DATASETS)
 
         self.assertEqual(registry.providers['biz'], ds_class)
+
+    def test_dataset_is_registered_for_each_dataset_in_metadata(self):
+        class TestDataset:
+            metadata = {
+                'datasets': {
+                    'magic': {
+                        'test1': [],
+                        'test2': []
+                    }
+                }
+            }
+        test_registry = DatasetRegistry()
+        test_registry._datasets_initialized = time.time()
+        test_registry.register_dataset('DSN_TEST_DATASET', TestDataset)
+
+        self.assertEqual(test_registry.get_all_datasets(), {
+            'test1': TestDataset,
+            'test2': TestDataset
+        })
+
+    def test_init_dataset_creates_dataset_class(self):
+        row = dict(
+            schema='test',
+            table_name='test_table',
+            name='test_name',
+            name_field='description',
+            geometry_type='POLYGON',
+            geometry_field='geometry',
+            id_field='id',
+        )
+        test_registry = DatasetRegistry()
+        test_registry._datasets_initialized = time.time()
+        result = test_registry.init_dataset(row, 'TestDataset', 'DSN_TEST_DATASET')
+
+        self.assertTrue(issubclass(result, datasource.DataSourceBase))
+        self.assertEqual(result.metadata['geofield'], row['geometry_field'])
+        self.assertEqual(result.metadata['datasets'], {'vsd': {'test_name': 'test.test_table'}})
+        self.assertEqual(result.metadata['fields'][0], "description as display")
+        self.assertEqual(result.metadata['fields'][1], "cast('vsd/test_name' as varchar(30)) as type")
+        self.assertEqual(
+            result.metadata['fields'][2],
+            "'https://api.data.amsterdam.nl/vsd/test_name/' || id || '/'  as uri",
+        )
+        self.assertEqual(result.metadata['fields'][3], "geometry as geometrie")
+        self.assertEqual(result.metadata['fields'][4], "id as id")
+        self.assertEqual(test_registry.providers, dict(test_name=result))
+
+    def test_init_dataset_defaults_schema_to_public(self):
+        row = dict(
+            schema=None,
+            table_name='test_table',
+            name='test_name',
+            name_field='description',
+            geometry_type='POLYGON',
+            geometry_field='geometry',
+            id_field='id',
+        )
+        test_registry = DatasetRegistry()
+        result = test_registry.init_dataset(row, 'TestDataset', 'DSN_TEST_DATASET')
+
+        self.assertEqual(result.metadata['datasets'], {'vsd': {'test_name': 'public.test_table'}})
+
+    def test_init_dataset_defaults_operator_to_within(self):
+        row = dict(
+            schema=None,
+            table_name='test_table',
+            name='test_name',
+            name_field='description',
+            geometry_type='POINT',
+            geometry_field='geometry',
+            id_field='id',
+        )
+        test_registry = DatasetRegistry()
+        result = test_registry.init_dataset(row, 'TestDataset', 'DSN_TEST_DATASET')
+
+        self.assertEqual(result.metadata['operator'], 'within')
+
+    def test_init_dataset_sets_operator_to_contains_for_polygons(self):
+        row = dict(
+            schema=None,
+            table_name='test_table',
+            name='test_name',
+            name_field='description',
+            geometry_type='POLYGON',
+            geometry_field='geometry',
+            id_field='id',
+        )
+        test_registry = DatasetRegistry()
+        result = test_registry.init_dataset(row, 'TestDataset', 'DSN_TEST_DATASET')
+
+        self.assertEqual(result.metadata['operator'], 'contains')
+
+    def test_init_vsd_datasets_calling_init_dataset_for_each_catalog(self):
+        registry = DatasetRegistry()
+        registry.init_dataset = unittest.mock.MagicMock()
+        registry.init_vsd_datasets(dsn=config.DSN_VARIOUS_SMALL_DATASETS)
+
+        dbconn = dbconnection(config.DSN_VARIOUS_SMALL_DATASETS)
+
+        datasets = dbconn.fetch_dict("SELECT * FROM cat_dataset WHERE enable_geosearch = true")
+
+        self.assertEqual(len(registry.init_dataset.mock_calls), len(datasets))
+        for row in datasets:
+            self.assertIn(
+                unittest.mock.call(
+                    row=unittest.mock.ANY,
+                    class_name=row['name'].upper() + 'GenAPIDataSource',
+                    dsn_name='DSN_VARIOUS_SMALL_DATASETS'
+                ),
+                registry.init_dataset.mock_calls,
+            )
 
 
 if __name__ == '__main__':

--- a/web/geosearch/tests/test_dataset_registry.py
+++ b/web/geosearch/tests/test_dataset_registry.py
@@ -1,0 +1,16 @@
+import unittest
+
+from datapunt_geosearch import config
+from datapunt_geosearch import datasource
+from datapunt_geosearch.registry import registry
+
+
+class TestDatasetRegistry(unittest.TestCase):
+    def test_biz_class_registered_in_registry(self):
+        ds_class = datasource.get_dataset_class('biz', dsn=config.DSN_VARIOUS_SMALL_DATASETS)
+
+        self.assertEqual(registry.providers['biz'], ds_class)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Use registry to store information about datasources, including ones that are defined as static classes.