### PR TITLE
External dataset

### DIFF
--- a/web/geosearch/datapunt_geosearch/blueprints/engine.py
+++ b/web/geosearch/datapunt_geosearch/blueprints/engine.py
@@ -35,13 +35,16 @@ def generate_async(request_args):
 
 def fetch_data(sourceClass, request_args, datasets, retry=None):
     from datapunt_geosearch import config
-    try:
-        dsn = getattr(config, sourceClass.dsn_name)
-    except AttributeError:
-        _logger.error("Can not find configuration for {}.".format(
-            sourceClass.dsn_name
-        ), exc_info=True)
-        return []
+
+    dsn = None
+    if sourceClass.dsn_name is not None:
+        try:
+            dsn = getattr(config, sourceClass.dsn_name)
+        except AttributeError:
+            _logger.error("Can not find configuration for {}.".format(
+                sourceClass.dsn_name
+            ), exc_info=True)
+            return []
 
     datasource = sourceClass(dsn=dsn)
     datasource.use_rd = request_args['rd']

--- a/web/geosearch/datapunt_geosearch/datasource.py
+++ b/web/geosearch/datapunt_geosearch/datasource.py
@@ -505,8 +505,11 @@ registry.register_dataset('DSN_MUNITIE', MunitieMilieuDataSource)
 registry.register_dataset('DSN_MUNITIE', BominslagMilieuDataSource)
 registry.register_dataset('DSN_MONUMENTEN', MonumentenDataSource)
 
+parkeervakken_base_url = "https://api.data.amsterdam.nl"
+if "acc.api" in DATAPUNT_API_URL:
+    parkeervakken_base_url = "https://acc.api.data.amsterdam.nl"
 registry.register_external_dataset(name="parkeervakken",
-                                   base_url="https://acc.api.data.amsterdam.nl",
+                                   base_url=parkeervakken_base_url,
                                    path="parkeervakken/geosearch/",
                                    field_mapping=dict(
                                        display="Parkeervak {id}",

--- a/web/geosearch/datapunt_geosearch/datasource.py
+++ b/web/geosearch/datapunt_geosearch/datasource.py
@@ -505,11 +505,8 @@ registry.register_dataset('DSN_MUNITIE', MunitieMilieuDataSource)
 registry.register_dataset('DSN_MUNITIE', BominslagMilieuDataSource)
 registry.register_dataset('DSN_MONUMENTEN', MonumentenDataSource)
 
-parkeervakken_base_url = "https://api.data.amsterdam.nl"
-if "acc.api" in DATAPUNT_API_URL:
-    parkeervakken_base_url = "https://acc.api.data.amsterdam.nl"
 registry.register_external_dataset(name="parkeervakken",
-                                   base_url=parkeervakken_base_url,
+                                   base_url=DATAPUNT_API_URL,
                                    path="parkeervakken/geosearch/",
                                    field_mapping=dict(
                                        display="Parkeervak {id}",

--- a/web/geosearch/datapunt_geosearch/registry.py
+++ b/web/geosearch/datapunt_geosearch/registry.py
@@ -45,6 +45,30 @@ class DatasetRegistry:
                     )
                 self.providers[item] = dataset_class
 
+    def register_external_dataset(self, name, base_url, path, field_mapping=None):
+        from datapunt_geosearch.datasource import ExternalDataSource
+        class_name = "{}ExternalDataSource".format(name.upper())
+
+        meta = {
+            "base_url": base_url,
+            "datasets": {
+                name: {
+                    name: path
+                }
+            }
+        }
+        if field_mapping is not None:
+            meta["field_mapping"] = field_mapping
+
+        dataset_class = type(
+            class_name,
+            (ExternalDataSource,),
+            dict(metadata=meta)
+        )
+
+        self.register_dataset("EXT_{}".format(name.upper()), dataset_class)
+        return dataset_class
+
     def get_all_datasets(self):
         self.init_datasets()
         return self.providers

--- a/web/geosearch/static/geosearch.yml
+++ b/web/geosearch/static/geosearch.yml
@@ -99,6 +99,7 @@ paths:
               - beperking
               - kadastraal_object
               - biz
+              - parkeervakken
           description: >
             Dataset and/or subset name(s) to search in presented as comma separated list.
         - $ref: "#/parameters/xParam"

--- a/web/geosearch/tests/test_dataset_registry.py
+++ b/web/geosearch/tests/test_dataset_registry.py
@@ -196,6 +196,41 @@ class TestDatasetRegistry(unittest.TestCase):
             ],
         )
 
+    def test_register_external_dataset_registers_dataset(self):
+        test_registry = DatasetRegistry()
+        test_registry._datasets_initialized = time.time()
+
+        result = test_registry.register_external_dataset(name="test",
+                                                         base_url="http://localhost:8000",
+                                                         path="test/search/")
+
+        self.assertEqual(test_registry.datasets["EXT_TEST"], [result])
+        self.assertEqual(test_registry.providers["test"], result)
+
+    def test_register_external_dataset_creates_generator_for_external_datasource(self):
+        test_registry = DatasetRegistry()
+        test_registry._datasets_initialized = time.time()
+
+        result = test_registry.register_external_dataset(name="test",
+                                                         base_url="http://localhost:8000",
+                                                         path="test/search/")
+
+        instance = result()
+        self.assertTrue(isinstance(instance, datasource.ExternalDataSource))
+
+    def test_register_external_dataset_respects_field_mappring(self):
+        test_registry = DatasetRegistry()
+        test_registry._datasets_initialized = time.time()
+
+        result = test_registry.register_external_dataset(
+            name="test",
+            base_url="http://localhost:8000",
+            path="test/search/",
+            field_mapping=dict(id="test")
+        )
+
+        self.assertEqual(result.metadata["field_mapping"], dict(id="test"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/web/geosearch/tests/test_external_datasource.py
+++ b/web/geosearch/tests/test_external_datasource.py
@@ -1,0 +1,197 @@
+import time
+import unittest
+import unittest.mock
+from requests.exceptions import HTTPError
+
+from datapunt_geosearch import datasource
+from datapunt_geosearch.registry import DatasetRegistry
+
+
+class TestExternalDataSource(unittest.TestCase):
+    def test_execute_applies_dataset_filtering(self):
+        test_datasource = datasource.ExternalDataSource(meta=dict(
+            base_url="http://localhost:8000",
+            datasets=dict(test=dict(test="test/geosearch/")),
+        ))
+
+        test_datasource.x = 129569.4
+        test_datasource.y = 479968.42
+
+        with unittest.mock.patch("datapunt_geosearch.datasource.ExternalDataSource.fetch_data") as fetch_mock:
+            result = test_datasource.execute_queries(datasets=["google"])
+
+        self.assertEqual(result, [])
+        self.assertEqual(fetch_mock.mock_calls, [])
+
+    def test_execute_queries_bypasses_x_and_y(self):
+        test_datasource = datasource.ExternalDataSource(meta=dict(
+            base_url="http://localhost:8000",
+            datasets=dict(test=dict(test="test/geosearch/")),
+        ))
+
+        test_datasource.x = 129569.4
+        test_datasource.y = 479968.42
+
+        with unittest.mock.patch("datapunt_geosearch.datasource.ExternalDataSource.fetch_data") as fetch_mock:
+            fetch_mock.return_value = []
+
+            test_datasource.execute_queries()
+
+        self.assertEqual(fetch_mock.mock_calls, [unittest.mock.call(
+            dataset_name="test/test", subset_url="test/geosearch/", request_params=dict(x=129569.4, y=479968.42)
+        )])
+
+    def test_execute_queries_bypasses_limit_if_set(self):
+        test_datasource = datasource.ExternalDataSource(meta=dict(
+            base_url="http://localhost:8000",
+            datasets=dict(test=dict(test="test/geosearch/")),
+        ))
+
+        test_datasource.x = 129569.4
+        test_datasource.y = 479968.42
+        test_datasource.limit = 1000
+
+        with unittest.mock.patch("datapunt_geosearch.datasource.ExternalDataSource.fetch_data") as fetch_mock:
+            fetch_mock.return_value = []
+
+            test_datasource.execute_queries()
+
+        self.assertEqual(fetch_mock.mock_calls, [unittest.mock.call(
+            dataset_name="test/test",
+            subset_url="test/geosearch/",
+            request_params=dict(x=129569.4, y=479968.42, limit=1000)
+        )])
+
+    def test_execute_queries_bypasses_radius_if_set(self):
+        test_datasource = datasource.ExternalDataSource(meta=dict(
+            base_url="http://localhost:8000",
+            datasets=dict(test=dict(test="test/geosearch/")),
+        ))
+
+        test_datasource.x = 129569.4
+        test_datasource.y = 479968.42
+        test_datasource.limit = 1000
+        test_datasource.radius = 30
+
+        with unittest.mock.patch("datapunt_geosearch.datasource.ExternalDataSource.fetch_data") as fetch_mock:
+            fetch_mock.return_value = []
+
+            test_datasource.execute_queries()
+
+        self.assertEqual(fetch_mock.mock_calls, [unittest.mock.call(
+            dataset_name="test/test",
+            subset_url="test/geosearch/",
+            request_params=dict(x=129569.4, y=479968.42, limit=1000, radius=30)
+        )])
+
+    def test_fetch_data_formats_search_url_using_base_url(self):
+        test_datasource = datasource.ExternalDataSource(meta=dict(
+            base_url="http://localhost:8000",
+            datasets=dict(test=dict(test="test/geosearch/")),
+        ))
+
+        request_params = dict(x=129569.4, y=479968.42)
+
+        with unittest.mock.patch("requests.get") as requests_mock:
+            response_mock = unittest.mock.MagicMock()
+            response_mock.json = lambda: [{"id": "31"}]
+            requests_mock.return_value = response_mock
+
+            result = test_datasource.fetch_data(
+                dataset_name="test/test",
+                subset_url="test/search",
+                request_params=request_params
+            )
+
+        self.assertEqual(result, [{"properties": {"id": "31", "type": "test/test"}}])
+        self.assertEqual(requests_mock.mock_calls, [unittest.mock.call(
+            "http://localhost:8000/test/search", params=request_params, timeout=1
+        )])
+
+    def test_fetch_data_will_return_empty_result_on_error(self):
+        test_datasource = datasource.ExternalDataSource(meta=dict(
+            base_url="http://localhost:8000",
+            datasets=dict(test=dict(test="test/geosearch/")),
+        ))
+
+        request_params = dict(x=129569.4, y=479968.42)
+
+        with unittest.mock.patch("datapunt_geosearch.datasource._logger") as logger_mock:
+            with unittest.mock.patch("requests.get") as requests_mock:
+                requests_mock.side_effect = HTTPError('meh.')
+
+                result = test_datasource.fetch_data(
+                    dataset_name="test/test",
+                    subset_url="test/search",
+                    request_params=request_params
+                )
+
+        self.assertEqual(result, [])
+        self.assertEqual(logger_mock.mock_calls, [unittest.mock.call.warning(
+            "Failed to fetch data from http://localhost:8000/test/search. Error 'meh.'."
+        )])
+
+    def test_format_result_applies_field_mapping(self):
+        test_datasource = datasource.ExternalDataSource(meta=dict(
+            base_url="http://localhost:8000",
+            datasets=dict(test=dict(test="test/geosearch/")),
+            field_mapping=dict(
+                display="Test {id}",
+                uri="{base_url}{_links[self][href]}"
+            )
+        ))
+
+        result = test_datasource.format_result(dataset_name='test/test', result=[{
+            "_links": {
+                "self": {
+                    "href": "/test/test/129569479969/"
+                }
+            },
+            "id": "129569479969",
+            "geometrie": {
+                "type": "MultiPolygon",
+                "coordinates": []
+            }
+        }])
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["properties"]["id"], "129569479969")
+        self.assertEqual(result[0]["properties"]["display"], "Test 129569479969")
+        self.assertEqual(result[0]["properties"]["uri"], "http://localhost:8000/test/test/129569479969/")
+
+    def test_format_result_not_breaking_when_incorrect_field_mapping_set(self):
+        test_datasource = datasource.ExternalDataSource(meta=dict(
+            base_url="http://localhost:8000",
+            datasets=dict(test=dict(test="test/geosearch/")),
+            field_mapping=dict(
+                display="Test {id}",
+                uri="{wrong_key}"
+            )
+        ))
+
+        with unittest.mock.patch("datapunt_geosearch.datasource._logger") as logger_mock:
+            result = test_datasource.format_result(dataset_name='test/test', result=[{
+                "id": "129569479969",
+            }])
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["properties"]["id"], "129569479969")
+        self.assertEqual(result[0]["properties"]["display"], "Test 129569479969")
+        self.assertFalse("uri" in result[0]["properties"].keys())
+        self.assertEqual(logger_mock.mock_calls, [
+            unittest.mock.call.error("Incorrect format template: uri in test/test.")
+        ])
+
+    def test_external_datasource_can_be_registered_in_registry(self):
+        test_registry = DatasetRegistry()
+        test_registry._datasets_initialized = time.time()
+
+        test_datasource = test_registry.register_external_dataset(
+            name="test",
+            base_url="http://localhost:8000",
+            path="test/geosearch/"
+        )
+
+        self.assertEqual(test_registry.providers, dict(
+            test=test_datasource,
+        ))


### PR DESCRIPTION
Allows external geosearch sources to be used as regular datasets.

Includes definition of parkeervakken API:

```
registry.register_external_dataset(
    name="parkeervakken",
    base_url=DATAPUNT_API_URL,
    path="parkeervakken/geosearch/",
    field_mapping=dict(
        display=lambda _, item: f"Parkeervak {item['id']}",
        uri=lambda base_url, item: urllib.parse.urljoin(base_url, item['_links']['self']['href'])
    )
)
```

