### PR TITLE
DS-280. Avoid name collisions and use slash in Dataset names.

### DIFF
--- a/web/geosearch/datapunt_geosearch/datasource.py
+++ b/web/geosearch/datapunt_geosearch/datasource.py
@@ -87,8 +87,12 @@ class DataSourceBase(object):
         with self.dbconn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
             for dataset in self.meta['datasets']:
                 for dataset_indent, table in self.meta['datasets'][dataset].items():
-                    if len(datasets) and not (
-                            dataset in datasets or dataset_indent in datasets):
+                    dataset_key = f"{dataset}/{dataset_indent}"
+                    if len(datasets) and not any([
+                            dataset in datasets,
+                            dataset_indent in datasets,  # To Be Deprecated.
+                            dataset_key in datasets,
+                    ]):
                         # Actively filter datasets
                         continue
 

--- a/web/geosearch/datapunt_geosearch/registry.py
+++ b/web/geosearch/datapunt_geosearch/registry.py
@@ -35,6 +35,7 @@ class DatasetRegistry:
         for key in dataset_class.metadata["datasets"].keys():
             self.providers[key] = dataset_class
             for item in dataset_class.metadata["datasets"][key].keys():
+                item_key = f"{key}/{item}"
                 if (
                     item in self.providers.keys()
                     and self.providers[item] != dataset_class
@@ -44,7 +45,9 @@ class DatasetRegistry:
                             item, self.providers[item], dataset_class
                         )
                     )
+                # Backwards compatible providers.
                 self.providers[item] = dataset_class
+                self.providers[item_key] = dataset_class
 
     def register_external_dataset(self, name, base_url, path, field_mapping=None):
         from datapunt_geosearch.datasource import ExternalDataSource
@@ -264,7 +267,8 @@ class DatasetRegistry:
                 field_name_transformation=lambda field_id: slugify(field_id, sign="_")
             )
             if dataset is not None:
-                datasets[row["name"]] = dataset
+                key = f"{row['dataset_name']}/{row['name']}"
+                datasets[key] = dataset
         return datasets
 
 

--- a/web/geosearch/tests/conftest.py
+++ b/web/geosearch/tests/conftest.py
@@ -11,7 +11,8 @@ def dataservices_db():
     with dataservices_db_connection.cursor() as cursor:
         cursor.execute("""
             BEGIN;
-            CREATE TABLE IF NOT EXISTS "datasets_dataset" (
+            DROP TABLE IF EXISTS "datasets_dataset" CASCADE;
+            CREATE TABLE "datasets_dataset" (
               "id" serial NOT NULL PRIMARY KEY,
               "name" varchar(50) NOT NULL UNIQUE,
               "ordering" integer NOT NULL,
@@ -19,7 +20,8 @@ def dataservices_db():
               "schema_data" jsonb NOT NULL,
               "auth" varchar(150) NULL
             );
-            CREATE TABLE IF NOT EXISTS "datasets_datasettable" (
+            DROP TABLE IF EXISTS "datasets_datasettable" CASCADE;
+            CREATE TABLE "datasets_datasettable" (
               "id" serial NOT NULL PRIMARY KEY,
               "name" varchar(100) NOT NULL,
               "enable_geosearch" boolean NOT NULL,

--- a/web/geosearch/tests/test_dataset_registry.py
+++ b/web/geosearch/tests/test_dataset_registry.py
@@ -27,7 +27,13 @@ class TestDatasetRegistry(unittest.TestCase):
 
         self.assertEqual(
             test_registry.get_all_datasets(),
-            {"magic": TestDataset, "test1": TestDataset, "test2": TestDataset},
+            {
+                "magic": TestDataset,
+                "magic/test1": TestDataset,
+                "magic/test2": TestDataset,
+                "test1": TestDataset,
+                "test2": TestDataset,
+            },
         )
 
     def test_init_dataset_creates_dataset_class(self):
@@ -60,7 +66,10 @@ class TestDatasetRegistry(unittest.TestCase):
         )
         self.assertEqual(result.metadata["fields"][3], "geometry as geometrie")
         self.assertEqual(result.metadata["fields"][4], "id as id")
-        self.assertEqual(test_registry.providers, dict(vsd=result, test_name=result,))
+        self.assertEqual(
+            test_registry.providers,
+            {"vsd": result, "test_name": result, "vsd/test_name": result}
+        )
 
     def test_init_dataset_defaults_schema_to_public(self):
         row = dict(
@@ -224,9 +233,11 @@ class TestDatasetRegistry(unittest.TestCase):
             self.assertEqual(len(datasets.keys()), 1)
             self.assertEqual(
                 test_registry.providers,
-                dict(
-                    test_dataset=datasets["test_name"], test_name=datasets["test_name"]
-                ),
+                {
+                    "test_dataset": datasets["test_dataset/test_name"],
+                    "test_name": datasets["test_dataset/test_name"],
+                    "test_dataset/test_name": datasets["test_dataset/test_name"],
+                },
             )
 
     def test_init_dataservices_dataset_with_authorizations(self):

--- a/web/geosearch/tests/test_external_datasource.py
+++ b/web/geosearch/tests/test_external_datasource.py
@@ -196,6 +196,7 @@ class TestExternalDataSource(unittest.TestCase):
             path="test/geosearch/"
         )
 
-        self.assertEqual(test_registry.providers, dict(
-            test=test_datasource,
-        ))
+        self.assertEqual(test_registry.providers, {
+            "test": test_datasource,
+            "test/test": test_datasource,
+        })

--- a/web/geosearch/tests/test_search_everywhere.py
+++ b/web/geosearch/tests/test_search_everywhere.py
@@ -50,3 +50,14 @@ class SearchEverywhereTestCase(unittest.TestCase):
             json_response = json.loads(response.data)
             self.assertEqual(json_response['type'], 'FeatureCollection')
             self.assertEqual(len(json_response['features']), 1)
+
+    @pytest.mark.usefixtures("dataservices_fake_data")
+    def test_search_in_dataservices_with_dataset_table__results_in_correct_result(self):
+        # Force registry to reload dataservices datasources
+        registry._datasets_initialized = None
+
+        with self.app.test_client() as client:
+            response = client.get('/?x=123282.6&y=487674.8&radius=1&datasets=fake/fake_public')
+            json_response = json.loads(response.data)
+            self.assertEqual(json_response['type'], 'FeatureCollection')
+            self.assertEqual(len(json_response['features']), 1)

--- a/web/requirements_dev.txt
+++ b/web/requirements_dev.txt
@@ -1,2 +1,2 @@
 -r requirements.txt
-pytest
+pytest==5.3.5


### PR DESCRIPTION
Backwards compatible version,
as we do not know what's going to break.