### PR TITLE
Making geosearch more transparent to users. 2 new status pages added.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ services:
       POSTGRES_USER: monumenten
     volumes:
         - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
+    extra_hosts:
+      admin.data.amsterdam.nl: 10.243.16.4
 #  tellus_db:
 #    image: amsterdam/postgres11
 #    ports:
@@ -66,6 +68,8 @@ services:
       POSTGRES_PASSWORD: insecure
     volumes:
        - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
+    extra_hosts:
+      admin.data.amsterdam.nl: 10.243.16.4
   web:
       build: ./web
       ports:

--- a/web/geosearch/datapunt_geosearch/blueprints/search.py
+++ b/web/geosearch/datapunt_geosearch/blueprints/search.py
@@ -97,6 +97,7 @@ def search_catalogus():
         for name, dataset in registry.get_all_datasets().items()
         if dataset.check_scopes(scopes=get_current_authz_scopes())
     ]
+
     return jsonify({'datasets': dataset_names})
 
 

--- a/web/geosearch/datapunt_geosearch/registry.py
+++ b/web/geosearch/datapunt_geosearch/registry.py
@@ -18,7 +18,7 @@ class DatasetRegistry:
     Dataset Registry.
     """
 
-    INITIALIZE_DELAY = 600  # 10 minutes
+    INITIALIZE_DELAY = 300  # 5 minutes
 
     def __init__(self, delay=None):
         # Datasets is a dictionary of DSN => Datasets.

--- a/web/geosearch/tests/test_health.py
+++ b/web/geosearch/tests/test_health.py
@@ -1,0 +1,34 @@
+import datetime
+import json
+import unittest
+import unittest.mock
+
+from datapunt_geosearch import config, create_app
+from datapunt_geosearch.registry import registry
+
+
+class HealthTestCase(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app(config=config)
+
+    def test_system_status(self):
+        # Simulate that registry initiation happened 10 seconds ago.
+        registry._datasets_initialized = (datetime.datetime.now() - datetime.timedelta(seconds=100)).timestamp()
+        with self.app.test_client() as client:
+            response = client.get('/status')
+            self.assertEqual(response.status_code, 200)
+            json_response = json.loads(response.data)
+            self.assertEqual(int(json_response['Time since last refresh']), 100)
+            self.assertEqual(json_response['Datasets initialized'], registry._datasets_initialized)
+            self.assertEqual(json_response['Delay'], registry.INITIALIZE_DELAY)
+
+    def test_force_refresh(self):
+        # Simulate that registry initiation happened 10 seconds ago.
+        registry._datasets_initialized = (datetime.datetime.now() - datetime.timedelta(seconds=100)).timestamp()
+        with self.app.test_client() as client:
+            response = client.get('/status/force-refresh')
+            self.assertEqual(response.status_code, 200)
+            json_response = json.loads(response.data)
+            self.assertLess(int(json_response['Time since last refresh']), 5)
+            self.assertEqual(json_response['Datasets initialized'], registry._datasets_initialized)
+            self.assertEqual(json_response['Delay'], registry.INITIALIZE_DELAY)


### PR DESCRIPTION
We've seen problems with datasets being cached by geosearch. This PR makes it a little easier to debug this kind of problems, as well as allowing us to refresh datasets when needed.