### PR TITLE
Geosearch refactor round 0

### DIFF
--- a/.jenkins/docker-compose-test.yml
+++ b/.jenkins/docker-compose-test.yml
@@ -1,9 +1,8 @@
+# Compose file used for testing in CI
 version: '3.0'
 services:
   bag_v11_db:
     image: amsterdam/postgres11
-    ports:
-      - "5405:5432"
     environment:
       POSTGRES_PASSWORD: insecure
       POSTGRES_DB: bag_v11
@@ -21,11 +20,6 @@ services:
     environment:
       POSTGRES_PASSWORD: insecure
       POSTGRES_USER: milieuthemas
-#  tellus_db:
-#    image: amsterdam/postgres11
-#    environment:
-#      POSTGRES_PASSWORD: insecure
-#      POSTGRES_USER: tellus
   monumenten_db:
     image: amsterdam/postgres11
     environment:
@@ -43,4 +37,22 @@ services:
       POSTGRES_USER: dataservices
   web_test:
     build: ../web
-    command: python test_dataset.py
+    environment:
+      - BAG_V11_DB_USER_OVERRIDE=bag_v11
+      - NAP_DB_USER_OVERRIDE=nap
+      - MILIEUTHEMAS_DB_USER_OVERRIDE=milieuthemas
+      - MONUMENTEN_DB_USER_OVERRIDE=monumenten
+      - VARIOUS_SMALL_DATASETS_DB_USER_OVERRIDE=various_small_datasets
+      - DATASERVICES_DB_USER_OVERRIDE=dataservices
+      - BAG_V11_DB_PASSWORD_OVERRIDE=insecure
+      - NAP_DB_PASSWORD_OVERRIDE=insecure
+      - MILIEUTHEMAS_DB_PASSWORD_OVERRIDE=insecure
+      - MONUMENTEN_DB_PASSWORD_OVERRIDE=insecure
+      - VARIOUS_SMALL_DATASETS_DB_PASSWORD_OVERRIDE=insecure
+      - DATASERVICES_DB_PASSWORD_OVERRIDE=insecure
+      - BAG_V11_DB_HOST_OVERRIDE=bag_v11_db
+      - NAP_DB_HOST_OVERRIDE=nap_db
+      - MILIEUTHEMAS_DB_HOST_OVERRIDE=milieuthemas_db
+      - MONUMENTEN_DB_HOST_OVERRIDE=monumenten_db
+      - VARIOUS_SMALL_DATASETS_DB_HOST_OVERRIDE=various_small_datasets_db
+      - DATASERVICES_DB_HOST_OVERRIDE=dataservices_db

--- a/.jenkins/docker-compose.yml
+++ b/.jenkins/docker-compose.yml
@@ -23,13 +23,6 @@ services:
       environment:
         POSTGRES_PASSWORD: insecure
         POSTGRES_USER: milieuthemas
-#  tellus_db:
-#      image: amsterdam/postgres11
-#      ports:
-#        - "5409:5432"
-#      environment:
-#        POSTGRES_PASSWORD: insecure
-#        POSTGRES_USER: tellus
   monumenten_db:
       image: amsterdam/postgres11
       ports:
@@ -53,4 +46,3 @@ services:
         POSTGRES_USER: dataservices
   web_test:
     build: ../web
-    command: python test_dataset.py

--- a/README.md
+++ b/README.md
@@ -1,23 +1,19 @@
-# setup
+# Setup of local development
 
+Local development is done using docker.
 
-Update different project databases with current data:
-bag_backend and meetbouten for now
+Update different project databases with current data dumps from the objectstore:
 
     docker-compose up -d
-    docker-compose exec bag_v11_db update-db.sh  bag_v11 <your_username>
-    docker-compose exec nap_db update-db.sh nap <your_username>
-    docker-compose exec milieuthemas_db update-db.sh milieuthemas <your_username>
-    docker-compose exec monumenten_db update-db.sh monumenten <your_username>
-    docker-compose exec various_small_datasets_db update-db.sh various_small_datasets  <your_username>
-    docker-compose exec dataservices_db update-db.sh dataservices <your_username>
+    docker-compose exec database update-db.sh bag_v11
+    docker-compose exec database update-db.sh nap
+    docker-compose exec database update-db.sh milieuthemas
+    docker-compose exec database update-db.sh monumenten
+    docker-compose exec database update-db.sh various_small_datasets
+    docker-compose exec database update-db.sh datasets
 
-    pip install -r requirements_dev.txt
-
-test postgres spatial queries:
-
-    cd web/geosearch
-	python test_dataset.py
+Running the testsuite
+    docker-compose exec web pytest
 
 #### NOTE that this testsuite uses dumps from production to make assertions about the data, the assertions are therefore *not deterministic*
 #### this must be fixed in the near future

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,70 +1,12 @@
 version: '3.0'
 services:
-  bag_v11_db:
+  database:
     image: amsterdam/postgres11
     ports:
-      - "5405:5432"
+       - "5432:5432"
     environment:
-      POSTGRES_PASSWORD: insecure
-      POSTGRES_DB: bag_v11
-      POSTGRES_USER: bag_v11
-    volumes:
-        - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
-  nap_db:
-    image: amsterdam/postgres11
-    ports:
-      - "5401:5432"
-    environment:
-      POSTGRES_DB: nap
-      POSTGRES_USER: nap
-      POSTGRES_PASSWORD: insecure
-    volumes:
-        - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
-  milieuthemas_db:
-    image: amsterdam/postgres11
-    ports:
-      - "5402:5432"
-    environment:
-      POSTGRES_PASSWORD: insecure
-      POSTGRES_USER: milieuthemas
-    volumes:
-        - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
-  monumenten_db:
-    image: amsterdam/postgres11
-    ports:
-      - "5412:5432"
-    environment:
-      POSTGRES_PASSWORD: insecure
-      POSTGRES_USER: monumenten
-    volumes:
-        - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
-    extra_hosts:
-      admin.data.amsterdam.nl: 10.243.16.4
-#  tellus_db:
-#    image: amsterdam/postgres11
-#    ports:
-#      - "5409:5432"
-#    environment:
-#      POSTGRES_PASSWORD: insecure
-#      POSTGRES_USER: tellus
-#    volumes:
-#        - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
-  various_small_datasets_db:
-    image: amsterdam/postgres11
-    ports:
-       - "5408:5432"
-    environment:
-      POSTGRES_PASSWORD: insecure
-      POSTGRES_USER: various_small_datasets
-    volumes:
-       - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
-  dataservices_db:
-    image: amsterdam/postgres11
-    ports:
-       - "5409:5432"
-    environment:
-      POSTGRES_DB: dataservices
-      POSTGRES_USER: dataservices
+      POSTGRES_DB: postgres
+      POSTGRES_USER: insecure
       POSTGRES_PASSWORD: insecure
     volumes:
        - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
@@ -74,6 +16,8 @@ services:
       build: ./web
       ports:
         - "8022:8000"
+      volumes:
+        - "./web/geosearch:/app"
       environment:
         - UWSGI_HTTP=0.0.0.0:8000
         - UWSGI_STATS=0.0.0.0:9191
@@ -81,3 +25,21 @@ services:
         - UWSGI_CALLABLE=app
         - UWSGI_MASTER=1
         - UWSGI_MASTER=4
+        - BAG_V11_DB_USER_OVERRIDE=insecure
+        - NAP_DB_USER_OVERRIDE=insecure
+        - MILIEUTHEMAS_DB_USER_OVERRIDE=insecure
+        - MONUMENTEN_DB_USER_OVERRIDE=insecure
+        - VARIOUS_SMALL_DATASETS_DB_USER_OVERRIDE=insecure
+        - DATASERVICES_DB_USER_OVERRIDE=insecure
+        - BAG_V11_DB_PASSWORD_OVERRIDE=insecure
+        - NAP_DB_PASSWORD_OVERRIDE=insecure
+        - MILIEUTHEMAS_DB_PASSWORD_OVERRIDE=insecure
+        - MONUMENTEN_DB_PASSWORD_OVERRIDE=insecure
+        - VARIOUS_SMALL_DATASETS_DB_PASSWORD_OVERRIDE=insecure
+        - DATASERVICES_DB_PASSWORD_OVERRIDE=insecure
+        - BAG_V11_DB_HOST_OVERRIDE=database
+        - NAP_DB_HOST_OVERRIDE=database
+        - MILIEUTHEMAS_DB_HOST_OVERRIDE=database
+        - MONUMENTEN_DB_HOST_OVERRIDE=database
+        - VARIOUS_SMALL_DATASETS_DB_HOST_OVERRIDE=database
+        - DATASERVICES_DB_HOST_OVERRIDE=database

--- a/web/geosearch/create_import_index.py
+++ b/web/geosearch/create_import_index.py
@@ -25,7 +25,6 @@ uitgevoerdonderzoek 136
 buurtcombinatie 99
 biz 49
 grootstedelijkgebied 36
-tellus 28
 gebiedsgerichtwerken 22
 gevrijwaardgebied 19
 stadsdeel 8
@@ -42,7 +41,6 @@ from datapunt_geosearch.datasource import BagDataSource, dbconnection
 from datapunt_geosearch.datasource import BominslagMilieuDataSource
 from datapunt_geosearch.datasource import MunitieMilieuDataSource
 from datapunt_geosearch.datasource import NapMeetboutenDataSource
-# from datapunt_geosearch.datasource import TellusDataSource
 from datapunt_geosearch.datasource import MonumentenDataSource
 from datapunt_geosearch.datasource import get_dataset_class, get_all_dataset_names
 
@@ -70,10 +68,6 @@ sources = {
         'ds': NapMeetboutenDataSource,
         'config': DSN_NAP
     },
-    # "tellus": {
-    #     'ds': TellusDataSource,
-    #     'config': DSN_TELLUS
-    # },
 }
 
 

--- a/web/geosearch/datapunt_geosearch/blueprints/search.py
+++ b/web/geosearch/datapunt_geosearch/blueprints/search.py
@@ -131,8 +131,6 @@ def search_in_datasets():
         ds = MunitieMilieuDataSource(dsn=current_app.config['DSN_MILIEU'])
     elif item == 'bominslag':
         ds = BominslagMilieuDataSource(dsn=current_app.config['DSN_MILIEU'])
-    # elif item == 'tellus':
-    #    ds = TellusDataSource(dsn=current_app.config['DSN_TELLUS'])
     elif item == 'monument':
         ds = MonumentenDataSource(dsn=current_app.config['DSN_MONUMENTEN'])
     elif item in {'openbareruimte', 'verblijfsobject', 'pand', 'ligplaats', 'standplaats', 'stadsdeel', 'buurt',

--- a/web/geosearch/datapunt_geosearch/config.py
+++ b/web/geosearch/datapunt_geosearch/config.py
@@ -1,54 +1,16 @@
 """
 Contains the different configs for the datapunt geosearch application
 """
-import json
 import logging
 import os
 from typing import Dict
 
-import yaml
-
-import sentry_sdk
 from datapunt_geosearch.authz import get_keyset
 
 logger = logging.getLogger(__name__)
 
 
-def in_docker() -> bool:
-    """
-    Checks pid 1 cgroup settings to check with reasonable certainty we're in a
-    docker env.
-    :rtype: bool
-    :return: true when running in a docker container, false otherwise
-    """
-    # noinspection PyBroadException
-    try:
-        cgroup = open('/proc/1/cgroup', 'r').read()
-        return ':/docker/' in cgroup or ':/docker-ce/' in cgroup
-    except:
-        return False
-
-
-def get_variable(db: str, varname: str, docker_default: str,
-                 sa_default: str = None) -> str:
-    """
-    Retrieve variables taking into account env overrides and wetter we are
-    running in Docker or standalone (development)
-
-    :rtype: str
-    :param db: The database for which we are retrieving settings
-    :param varname: The variable to retrieve
-    :param docker_default: The default value (Running in docker)
-    :param sa_default: The default value (Running standalone)
-    :return: The applicable value of the requested variable
-    """
-    sa_default = docker_default if sa_default is None else sa_default
-
-    return os.getenv(f"{db}_DB_{varname}_OVERRIDE".upper(),
-                     docker_default if in_docker() else sa_default)
-
-
-def get_db_settings(db: str, docker_host: str, localport: str) -> Dict[str, str]:
+def get_db_settings(db: str) -> Dict[str, str]:
     """
     Get the complete settings for a given database. Taking all possible
     environments into account.
@@ -61,66 +23,38 @@ def get_db_settings(db: str, docker_host: str, localport: str) -> Dict[str, str]
              'username', 'password', 'host', 'port' and 'db'
     """
     return {
-        'username': get_variable(db=db, varname='user', docker_default=db),
-        'password': get_variable(db=db, varname='password',
-                                 docker_default='insecure'),
-        'host': get_variable(db=db, varname='host', docker_default=docker_host,
-                             sa_default='localhost'),
-        'port': get_variable(db=db, varname='port', docker_default='5432',
-                             sa_default=localport),
-        'db': get_variable(db=db, varname='database', docker_default=db)
+        'username': os.environ[f"{db.upper()}_DB_USER_OVERRIDE"],
+        'password': os.environ[f"{db.upper()}_DB_PASSWORD_OVERRIDE"],
+        'host': os.environ[f"{db.upper()}_DB_HOST_OVERRIDE"] ,
+        'port': os.getenv(f"{db.upper()}_DB_PORT_OVERRIDE", "5432"),
+        'db': db,
     }
 
 
 _db_connection_string = 'postgresql://{username}:{password}@{host}:{port}/{db}'
 
 
-DSN_BAG = _db_connection_string.format(
-    **get_db_settings(db='bag_v11',
-                      docker_host='bag_v11_db',
-                      localport='5405'))
-
-DSN_NAP = _db_connection_string.format(
-    **get_db_settings(db='nap',
-                      docker_host='nap_db',
-                      localport='5401'))
-
-DSN_MILIEU = _db_connection_string.format(
-    **get_db_settings(db='milieuthemas',
-                      docker_host='milieuthemas_db',
-                      localport='5402'))
-
-# DSN_TELLUS = _db_connection_string.format(
-#     **get_db_settings(db='tellus',
-#                       docker_host='tellus_db',
-#                       localport='5409'))
-
-DSN_MONUMENTEN = _db_connection_string.format(
-    **get_db_settings(db='monumenten',
-                      docker_host='monumenten_db',
-                      localport='5412'))
 
 
-DSN_VARIOUS_SMALL_DATASETS = _db_connection_string.format(
-    **get_db_settings(db='various_small_datasets',
-                      docker_host='various_small_datasets_db',
-                      localport='5408'))
+def _make_conn_str(name: str) -> str:
+    return _db_connection_string.format(**get_db_settings('name'))
 
 
-DSN_DATASERVICES_DATASETS = _db_connection_string.format(
-    **get_db_settings(db='dataservices',
-                      docker_host='dataservices_db',
-                      localport='5409'))
-
+DSN_BAG = _make_conn_str('bag_v11')
+DSN_NAP = _make_conn_str('nap')
+DSN_MILIEU = _make_conn_str('milieuthemas')
+DSN_MONUMENTEN = _make_conn_str('monumenten')
+DSN_VARIOUS_SMALL_DATASETS = _make_conn_str('various_small_datasets')
+DSN_DATASERVICES_DATASETS = _make_conn_str('dataservices')
 
 logging.debug('Database config:\n'
               'Bag: %s\n'
               'Nap: %s\n'
               'Milieu: %s\n'
- #             'Tellus: %s\n'
               'Monumenten: %s\n',
-              'Various Small Datasets',
-              DSN_BAG, DSN_NAP, DSN_MILIEU, DSN_MONUMENTEN, DSN_VARIOUS_SMALL_DATASETS)
+              'Various Small Datasets: %s\n',
+              'Dataservices: %s\n',
+              DSN_BAG, DSN_NAP, DSN_MILIEU, DSN_MONUMENTEN, DSN_VARIOUS_SMALL_DATASETS, DSN_DATASERVICES_DATASETS)
 
 DATAPUNT_API_URL = os.getenv(
     'DATAPUNT_API_URL', 'https://api.data.amsterdam.nl/')

--- a/web/geosearch/tests/test_monumenten_dataset.py
+++ b/web/geosearch/tests/test_monumenten_dataset.py
@@ -27,7 +27,7 @@ class TestMonumentenDataset(unittest.TestCase):
 
         results = ds.query(x, y, radius=radius)
 
-        self.assertEqual(len(results['features']), 53)
+        self.assertEqual(len(results['features']), 54)
 
         results = ds.query(x, y, radius=radius, limit=limit)
         self.assertEqual(len(results['features']), 4)


### PR DESCRIPTION
* Use SQL Composition for point queries (this still needs some work but it requires refactoring the way dynamic parts of the query are stored on the class, which id rather do in a separate  PR. Consider this an explorative refactor)
* Move configuration from the code to the environment as much as possible (and reasonable).
* Simplify local development by loading all dbs into a single container
* Remove Telus related stuff
* Update a test assertion because the online data changed (verified this manually against dump). Replacing this with fixtures will be a follow-up PR.