### PR TITLE
When a database connection is None, it's not usable

### DIFF
--- a/web/geosearch/datapunt_geosearch/db.py
+++ b/web/geosearch/datapunt_geosearch/db.py
@@ -83,7 +83,7 @@ class _DBConnection:
             yield self._conn
         except psycopg2.Error as e:
             _logger.critical("AUTHZ DatabaseError: {}".format(e))
-            if not self._is_usable():
+            if self._conn is not None and not self._is_usable():
                 with contextlib.suppress(psycopg2.Error):
                     self._conn.close()
                 self._conn = None


### PR DESCRIPTION
Previously, _DBConnection._is_usable would itself crash with an AttributeError instead of raising a Postgres exception.