### PR TITLE
End user context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,4 +48,5 @@ services:
         - VARIOUS_SMALL_DATASETS_DB_HOST_OVERRIDE=database
         - DATASERVICES_DB_HOST_OVERRIDE=database
         - TEST_SETTINGS_MODULE=datapunt_geosearch.test_config
-        - LOG_LEVEL=DEBUG
+        - LOG_LEVEL=INFO
+        - DATABASE_SET_ROLE=

--- a/jwt_keygen.py
+++ b/jwt_keygen.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+import argparse
+import json
+import pathlib
+import sys
+import time
+import uuid
+
+from jwcrypto.jwk import JWK
+from jwcrypto.jwt import JWT
+
+"""
+Utitility script for generating JSON web keys and JSON web tokens
+which can be used when testing geosearch. JWTs can contain private
+claims which are scopes as used in the authorization mechanism of
+amsterdam-schema.
+
+The key used by the development configuration of Geosearch is stored in
+test_jwk.json in the root folder of this repository.
+"""
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "scopes", nargs="*", help="Scopes added to the JWT as private claims"
+)
+parser.add_argument(
+    "--exp", default=None, type=int, help="Number of seconds to expiration"
+)
+
+JWK_PATH = pathlib.Path(__file__).parent / "test_jwk.json"
+
+
+def generate_jwk():
+    return JWK.generate(
+        kty="EC", crv="P-256", kid=str(uuid.uuid4()), key_ops=["verify", "sign"]
+    )
+
+
+def generate_jwt(scopes, exp):
+    """Generate a JWT, signed using the key stored at test_jwk.json.
+    If there is no key at this location, generate it and write it to
+    the file."""
+    if JWK_PATH.exists():
+        key = JWK(**json.load(open(JWK_PATH)))
+    else:
+        with open(JWK_PATH, "w+") as fp:
+            key = generate_jwk()
+            json.dump(key, fp, indent=2, sort_keys=True)
+
+    scopes = list(set(scopes))
+    now = int(time.time())
+    claims = {
+        "iat": now,
+        "scopes": scopes,
+        "sub": "test@test.nl",
+    }
+    if exp is not None:
+        claims["exp"] = now + exp
+
+    token = JWT(header={"alg": "ES256", "kid": key.kid}, claims=claims)
+    token.make_signed_token(key)
+
+    sys.stdout.write(token.serialize())
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    generate_jwt(args.scopes, args.exp)

--- a/test_jwk.json
+++ b/test_jwk.json
@@ -1,0 +1,12 @@
+{
+  "kty": "EC",
+  "key_ops": [
+    "verify",
+    "sign"
+  ],
+  "kid": "2aedafba-8170-4064-b704-ce92b7c89cc6",
+  "crv": "P-256",
+  "x": "6r8PYwqfZbq_QzoMA4tzJJsYUIIXdeyPA27qTgEJCDw=",
+  "y": "Cf2clfAfFuuCB06NMfIat9ultkMyrMQO9Hd2H7O9ZVE=",
+  "d": "N1vu0UQUp0vLfaNeM0EDbl4quvvL6m_ltjoAXXzkI3U="
+}

--- a/web/geosearch/create_import_index.py
+++ b/web/geosearch/create_import_index.py
@@ -73,7 +73,7 @@ master_index_table_name = "geo_master"
 
 
 def create_index_table(conn):
-    with conn.transaction_cursor() as cur:
+    with conn.cursor() as cur:
         # If something went wrong the previous time
         cur.execute(f"""DROP TABLE IF EXISTS {master_index_table_name}_new""")
         cur.execute(

--- a/web/geosearch/datapunt_geosearch/__init__.py
+++ b/web/geosearch/datapunt_geosearch/__init__.py
@@ -7,6 +7,14 @@ from flask_cors import CORS
 from sentry_sdk.integrations.flask import FlaskIntegration
 
 from datapunt_geosearch.blueprints import health, search
+from datapunt_geosearch.db import connection_cache
+
+
+def deactivate_user_context(e):
+    """Rollback the end user context on any db connections using it."""
+    for conn in connection_cache.values():
+        if conn._active_user:
+            conn.deactivate_end_user()
 
 
 def create_app(import_path: str = "datapunt_geosearch.config"):
@@ -22,5 +30,7 @@ def create_app(import_path: str = "datapunt_geosearch.config"):
     app.config.from_object(import_path)
     app.register_blueprint(search.search)
     app.register_blueprint(health.health)
+
+    app.teardown_request(deactivate_user_context)
 
     return app

--- a/web/geosearch/datapunt_geosearch/authz.py
+++ b/web/geosearch/datapunt_geosearch/authz.py
@@ -41,11 +41,14 @@ def check_authentication(request):
     Optionally check authentication via on request.
 
     Returns None if request contains no Authorization header.
-    In case Authorization header is correct - updates `g.authz_scopes` with
-     scopes from claims defined in JWT token.
+    In case Authorization header is correct
+        - sets scopes from claims defined in JWT token on appcontext
+        - sets user defined in JWT token on appcontext
+
     Aborts with 401 in case Authorization header contains incorrect token.
     """
     g.authz_scopes = None
+    g.token_subject = None
     token = get_token_from_request(request=request)
     if token is not None:
         try:
@@ -67,7 +70,7 @@ def check_authentication(request):
         claims = get_claims(jwt)
         if claims:
             g.authz_scopes = claims["scopes"]
-    return None
+            g.token_subject = claims["sub"]
 
 
 def get_token_from_request(request):

--- a/web/geosearch/datapunt_geosearch/base_config.py
+++ b/web/geosearch/datapunt_geosearch/base_config.py
@@ -4,6 +4,8 @@ from typing import Dict
 
 from datapunt_geosearch.authz import get_keyset
 
+DATABASE_SET_ROLE = os.getenv("DATABASE_SET_ROLE", False)
+
 
 def get_db_settings(db: str) -> Dict[str, str]:
     """

--- a/web/geosearch/datapunt_geosearch/blueprints/search.py
+++ b/web/geosearch/datapunt_geosearch/blueprints/search.py
@@ -116,6 +116,7 @@ def search_catalogus():
 
 
 @search.route("/search/", methods=["GET", "OPTIONS"])
+@authenticate
 @retry_on_psycopg2_error
 def search_in_datasets():
     """
@@ -186,6 +187,7 @@ def search_in_datasets():
 
 
 @search.route("/nap/", methods=["GET", "OPTIONS"])
+@authenticate
 @retry_on_psycopg2_error
 def search_geo_nap():
     """Performing a geo search for radius around a point using postgres"""
@@ -202,6 +204,7 @@ def search_geo_nap():
 
 
 @search.route("/monumenten/", methods=["GET", "OPTIONS"])
+@authenticate
 @retry_on_psycopg2_error
 def search_geo_monumenten():
     """Performing a geo search for radius around a point using postgres"""
@@ -221,6 +224,7 @@ def search_geo_monumenten():
 
 
 @search.route("/munitie/", methods=["GET", "OPTIONS"])
+@authenticate
 @retry_on_psycopg2_error
 def search_geo_munitie():
     """Performing a geo search for radius around a point using postgres"""
@@ -235,6 +239,7 @@ def search_geo_munitie():
 
 
 @search.route("/bominslag/", methods=["GET", "OPTIONS"])
+@authenticate
 @retry_on_psycopg2_error
 def search_geo_bominslag():
     """Performing a geo search for radius around a point using postgres"""
@@ -250,6 +255,7 @@ def search_geo_bominslag():
     return jsonify(resp)
 
 
+@authenticate
 @retry_on_psycopg2_error
 def _search_geo_bag():
     """Performing a geo search for radius around a point using postgres"""
@@ -263,6 +269,7 @@ def _search_geo_bag():
     return jsonify(resp)
 
 
+@authenticate
 @search.route("/bag/", methods=["GET", "OPTIONS"])
 def search_geo_bag():
     # shine new endpoint
@@ -270,6 +277,7 @@ def search_geo_bag():
 
 
 @search.route("/atlas/", methods=["GET", "OPTIONS"])
+@authenticate
 def search_geo_atlas():
     # old should be replaced
     return _search_geo_bag()
@@ -277,6 +285,7 @@ def search_geo_atlas():
 
 # This should be the last (catchall) route/view combination
 @search.route("/<string:dataset>/", methods=["GET", "OPTIONS"])
+@authenticate
 @retry_on_psycopg2_error
 def search_geo_genapi(dataset):
     """Performing a geo search for radius around a point using postgres.

--- a/web/geosearch/datapunt_geosearch/config.py
+++ b/web/geosearch/datapunt_geosearch/config.py
@@ -1,7 +1,8 @@
 import logging
 
-from datapunt_geosearch.base_config import DATAPUNT_API_URL  # noqa: F401
-from datapunt_geosearch.base_config import (
+from datapunt_geosearch.base_config import (  # noqa: F401
+    DATABASE_SET_ROLE,
+    DATAPUNT_API_URL,
     DEFAULT_SEARCH_DATASETS,
     JW_KEYSET,
     JWKS,
@@ -31,11 +32,13 @@ logging.debug(
          Milieu: %s\n\
          Monumenten: %s\n\
         Various Small Datasets: %s\n\
-        Dataservices: %s\n\n",
+        Dataservices: %s\n\
+        Role switching %s\n\n",
     DSN_BAG,
     DSN_NAP,
     DSN_MILIEU,
     DSN_MONUMENTEN,
     DSN_VARIOUS_SMALL_DATASETS,
     DSN_DATASERVICES_DATASETS,
+    "active" if DATABASE_SET_ROLE else "inactive",
 )

--- a/web/geosearch/datapunt_geosearch/datasource.py
+++ b/web/geosearch/datapunt_geosearch/datasource.py
@@ -37,16 +37,18 @@ class DataSourceBase:
     extra_where = ""
     temporal_bounds = None
     crs = None
+    # whether the db connection should switch end user context for querying
+    set_user_role = False
 
     def __init__(self, dsn=None, connection=None):
-        _logger.debug("Creating DataSource: %s" % self.dataset)
+        _logger.debug("Creating DataSource: %s" % self.__class__.__name__)
 
         if not dsn and connection is None:
             raise ValueError("dsn needs to be defined")
 
         if connection is None:
             try:
-                self.dbconn = dbconnection(dsn)
+                self.dbconn = dbconnection(dsn, set_user_role=self.set_user_role)
             except psycopg2.Error as e:
                 _logger.error("Error creating connection: %s" % e)
                 raise DataSourceException("error connecting to datasource") from e
@@ -129,7 +131,7 @@ class DataSourceBase:
                         )
 
                     if not len(rows):
-                        _logger.debug(table, "no results")
+                        _logger.debug("no results for table: %s", table)
                         continue
 
                     for row in rows:

--- a/web/geosearch/datapunt_geosearch/db.py
+++ b/web/geosearch/datapunt_geosearch/db.py
@@ -3,9 +3,23 @@ import functools
 import logging
 
 import psycopg2.extras
+from cachetools import LRUCache, cached
+from flask import current_app as app
+from flask import g
 from psycopg2 import Error as Psycopg2Error
+from psycopg2.errors import InvalidParameterValue
 
 _logger = logging.getLogger(__name__)
+
+USER_ROLE = "{user_email}_role"
+INTERNAL_ROLE = "medewerker_role"
+ANONYMOUS_ROLE = "anonymous_role"
+ANONYMOUS_APP_NAME = "geosearch-openbaar"
+
+
+def is_internal(user_email: str) -> bool:
+    """Tell whether a user is an internal user."""
+    return user_email.endswith("@amsterdam.nl")
 
 
 def retry_on_psycopg2_error(func):
@@ -33,29 +47,36 @@ def retry_on_psycopg2_error(func):
     return wrapper_retry
 
 
-@functools.lru_cache()
-def dbconnection(dsn):
-    """Creates an instance of _DBConnection and remembers the last one made."""
-    return _DBConnection(dsn)
+connection_cache = LRUCache(maxsize=128)
+
+
+@cached(cache=connection_cache)
+def dbconnection(dsn, set_user_role=False):
+    """Creates and caches instances of _DBConnection by DSN"""
+    return _DBConnection(dsn, set_user_role)
 
 
 class _DBConnection:
-    """Wraps a PostgreSQL database connection that reports crashes and tries
-    its best to repair broken connections.
+    """A PostgresQL database connection that
+        - reports crashes
+        - tries its best to repair broken connections
+        - optionally switches the user-role using SET ROLE
 
     NOTE: doesn't always work, but the failure scenario is very hard to
       reproduce. Also see https://github.com/psycopg/psycopg2/issues/263
     """
 
-    def __init__(self, *args, **kwargs):
-        self.conn_args = args
-        self.conn_kwargs = kwargs
+    def __init__(self, dsn, set_user_role):
+        self.set_user_role = set_user_role
+        self.dsn = dsn
         self._conn = None
+        self._active_user = None
         self._connect()
 
     def _connect(self):
         if self._conn is None:
-            self._conn = psycopg2.connect(*self.conn_args, **self.conn_kwargs)
+            self._conn = psycopg2.connect(self.dsn)
+            # Cursors will not run inside their own transactions
             self._conn.autocommit = True
 
     def _is_usable(self):
@@ -65,10 +86,87 @@ class _DBConnection:
         """
         try:
             self._conn.cursor().execute("SELECT 1")
-        except psycopg2.Error:
+        except Psycopg2Error:
             return False
         else:
             return True
+
+    def activate_end_user(self):
+        """Switch to the end-user role in the database."""
+        if not app.config["DATABASE_SET_ROLE"] or not self.set_user_role:
+            _logger.debug(
+                "End-user feature disabled (DATABASE_SET_ROLE=%s, set_user_role=%s)",
+                app.config["DATABASE_SET_ROLE"],
+                self.set_user_role,
+            )
+            return
+
+        user_email = g.token_subject
+        if not user_email:
+            _logger.debug("No end-user email, switching to anonymous role")
+            self._set_role(ANONYMOUS_ROLE, ANONYMOUS_APP_NAME)
+            return
+
+        if self._active_user == user_email:
+            _logger.debug("End-user already set, no need to switch roles again")
+            return
+
+        _logger.debug("%s: Activating end-user context for %s", user_email)
+
+        role_name = USER_ROLE.format(user_email=user_email)
+        try:
+            # BBN2: Exact account for specific access.
+            self._set_role(role_name, user_email)
+        except InvalidParameterValue as e:
+            # The role didn't exist.
+            if is_internal(user_email):
+                # BBN1: Internal employee, no specific account
+                self._set_role(INTERNAL_ROLE, user_email)
+            else:
+                _logger.exception(
+                    "External user %s has no database role %s", user_email, role_name
+                )
+                raise PermissionError(
+                    f"User {user_email} is not available in database"
+                ) from e
+
+    def _set_role(self, role_name, app_name):
+        # By starting a transaction, any connection pooling (e.g. PgBouncer)
+        # can also ensure the connection is not reused for another session.
+        with self._connection() as conn:
+            with conn.cursor() as c:
+                try:
+                    c.execute(
+                        "BEGIN; SET LOCAL ROLE %s; set application_name to %s;",
+                        (role_name, app_name),
+                    )
+                except Psycopg2Error as e:
+                    _logger.debug("Switch role failed for %s: %s", role_name, e)
+                    c.execute("ROLLBACK;")
+                    raise
+
+                self._active_user = role_name
+                _logger.info(
+                    "Activated end-user database role '%s' for '%s'",
+                    role_name,
+                    app_name,
+                )
+
+    def deactivate_end_user(self):
+        """Rollback the transaction when the local user was activated."""
+        if not self._active_user:
+            _logger.debug("Not rolling back end-user since there is no active user")
+
+        _logger.debug("End-user rollback for %s", self._active_user)
+        try:
+            with self._conn.cursor() as c:
+                c.execute("ROLLBACK;")
+            self._active_user = None
+        except Psycopg2Error as e:
+            _logger.debug(
+                "Unable to rollback end user context for: %s", self._active_user
+            )
+            _logger.debug("Database error %s", e)
 
     @contextlib.contextmanager
     def _connection(self):
@@ -81,7 +179,7 @@ class _DBConnection:
         try:
             self._connect()
             yield self._conn
-        except psycopg2.Error as e:
+        except Psycopg2Error as e:
             _logger.critical("AUTHZ DatabaseError: {}".format(e))
             if self._conn is not None and not self._is_usable():
                 with contextlib.suppress(psycopg2.Error):
@@ -90,16 +188,9 @@ class _DBConnection:
             raise e
 
     @contextlib.contextmanager
-    def transaction_cursor(self, cursor_factory=None):
-        """Yields a cursor with transaction."""
-        with self._connection() as transaction:
-            with transaction:
-                with transaction.cursor(cursor_factory=cursor_factory) as cur:
-                    yield cur
-
-    @contextlib.contextmanager
     def cursor(self, cursor_factory=None):
         """Yields a cursor without transaction."""
+        self.activate_end_user()
         with self._connection() as conn:
             with conn.cursor(cursor_factory=cursor_factory) as cur:
                 yield cur

--- a/web/geosearch/datapunt_geosearch/registry.py
+++ b/web/geosearch/datapunt_geosearch/registry.py
@@ -111,6 +111,7 @@ class DatasetRegistry:
         field_name_transformation=None,
         temporal_dimension=None,
         crs=None,
+        set_user_role=False,
     ):
         """
         Initialize dataset class and register it in registry based on row data
@@ -207,6 +208,7 @@ class DatasetRegistry:
                 "dsn_name": dsn_name,
                 "temporal_bounds": temporal_bounds,
                 "crs": crs,
+                "set_user_role": set_user_role,
             },
         )
 
@@ -347,6 +349,9 @@ class DatasetRegistry:
                 field_name_transformation=to_snake_case,
                 temporal_dimension=temporal_dimension,
                 crs=crs,
+                # Connections to the reference database must use role switching
+                # on Azure.
+                set_user_role=True,
             )
             if dataset is not None:
                 key = f"{row['dataset_name']}/{row['name']}"

--- a/web/geosearch/datapunt_geosearch/test_config.py
+++ b/web/geosearch/datapunt_geosearch/test_config.py
@@ -1,7 +1,7 @@
 import logging
 
-from datapunt_geosearch.base_config import DATAPUNT_API_URL  # noqa: F401
-from datapunt_geosearch.base_config import (
+from datapunt_geosearch.base_config import (  # noqa: F401
+    DATAPUNT_API_URL,
     DEFAULT_SEARCH_DATASETS,
     JW_KEYSET,
     JWKS,
@@ -47,3 +47,5 @@ logging.debug(
     DSN_VARIOUS_SMALL_DATASETS,
     DSN_DATASERVICES_DATASETS,
 )
+
+DATABASE_SET_ROLE = False

--- a/web/geosearch/tests/test_authz.py
+++ b/web/geosearch/tests/test_authz.py
@@ -42,7 +42,8 @@ class AuthzTestCase(unittest.TestCase):
         token = self.create_authz_token(subject="test@test.nl", scopes=["CA/W", "TEST"])
         with self.client() as client:
             response = client.get(
-                "/?x=123282.6&y=487674.8&radius=100", headers={"Authorization": token}
+                "/?x=123282.6&y=487674.8&radius=100",
+                headers={"Authorization": f"Bearer {token}"},
             )
             self.assertEqual(flask.g.authz_scopes, {"CA/W", "TEST"})
             self.assertEqual(response.status_code, 200)
@@ -66,7 +67,7 @@ class AuthzTestCase(unittest.TestCase):
         with self.client() as client:
             response = client.get(
                 "/?x=123282.6&y=487674.8&radius=1&datasets=fake_secret",
-                headers={"Authorization": token},
+                headers={"Authorization": f"Bearer {token}"},
             )
             self.assertEqual(flask.g.authz_scopes, {"TEST", "CA/W"})
             self.assertEqual(response.status_code, 200)
@@ -81,9 +82,10 @@ class AuthzTestCase(unittest.TestCase):
         with app.test_client() as client:
             response = client.get(
                 "/?x=123282.6&y=487674.8&radius=1&datasets=fake/fake_secret",
-                headers={"Authorization": token},
+                headers={"Authorization": f"Bearer {token}"},
             )
             self.assertEqual(flask.g.authz_scopes, {"CA/W", "TEST", "FAKE/SECRET"})
+            self.assertEqual(flask.g.token_subject, "test@test.nl")
             self.assertEqual(response.status_code, 200)
             json_response = json.loads(response.data)
             self.assertEqual(json_response["type"], "FeatureCollection")

--- a/web/geosearch/tests/test_catalogus_endpoint.py
+++ b/web/geosearch/tests/test_catalogus_endpoint.py
@@ -43,7 +43,7 @@ class CatalogusEndpointTestCase(unittest.TestCase):
     def test_correct_bearer_accepted_and_scopes_assigned(self):
         token = self.create_authz_token(subject="test@test.nl", scopes=["CA/W", "TEST"])
         with self.client() as client:
-            client.get("/catalogus/", headers={"Authorization": token})
+            client.get("/catalogus/", headers={"Authorization": f"Bearer {token}"})
             self.assertEqual(flask.g.authz_scopes, {"CA/W", "TEST"})
 
     def test_dataset_table_with_authorization_not_visible(self):
@@ -57,7 +57,9 @@ class CatalogusEndpointTestCase(unittest.TestCase):
     def test_dataset_table_with_authorization_not_visible_with_no_scope(self):
         token = self.create_authz_token(subject="test@test.nl", scopes=["CA/W", "TEST"])
         with self.client() as client:
-            response = client.get("/catalogus/", headers={"Authorization": token})
+            response = client.get(
+                "/catalogus/", headers={"Authorization": f"Bearer {token}"}
+            )
             self.assertEqual(flask.g.authz_scopes, {"TEST", "CA/W"})
             self.assertEqual(response.status_code, 200)
             json_response = json.loads(response.data)
@@ -68,7 +70,9 @@ class CatalogusEndpointTestCase(unittest.TestCase):
             subject="test@test.nl", scopes=["CA/W", "TEST", "FAKE/SECRET"]
         )
         with self.client() as client:
-            response = client.get("/catalogus/", headers={"Authorization": token})
+            response = client.get(
+                "/catalogus/", headers={"Authorization": f"Bearer {token}"}
+            )
             self.assertEqual(flask.g.authz_scopes, {"CA/W", "TEST", "FAKE/SECRET"})
             self.assertEqual(response.status_code, 200)
             json_response = json.loads(response.data)

--- a/web/geosearch/tests/test_user_context.py
+++ b/web/geosearch/tests/test_user_context.py
@@ -1,0 +1,103 @@
+import json
+
+from flask import current_app as app
+from flask import g
+
+from datapunt_geosearch import db
+
+
+def test_user_not_set_by_default(test_client, dataservices_db, dataservices_fake_data):
+    """Prove that usercontext not set when not configured"""
+    with test_client() as client:
+        client.get("/?datasets=fake/fake_public&x=0&y=0")
+        assert (
+            db.dbconnection(
+                app.config["DSN_DATASERVICES_DATASETS"], set_user_role=True
+            )._active_user
+            is None
+        )
+
+
+def test_anonymous_when_no_jwt(
+    active_user_context,
+    test_client,
+    dataservices_db,
+    dataservices_fake_data,
+    role_configuration,
+):
+    with test_client() as client:
+        response = client.get("/?x=123282.6&y=487674.8&radius=1&datasets=fake")
+        json_response = json.loads(response.data)
+        assert len(json_response["features"]) == 1
+        assert (
+            db.dbconnection(
+                app.config["DSN_DATASERVICES_DATASETS"], set_user_role=True
+            )._active_user
+            == db.ANONYMOUS_ROLE
+        )
+
+    # The user context must be cleaned up when the request context is popped
+    assert (
+        db.dbconnection(
+            app.config["DSN_DATASERVICES_DATASETS"], set_user_role=True
+        )._active_user
+        is None
+    )
+
+
+def test_end_user_when_jwt(
+    active_user_context,
+    test_client,
+    dataservices_db,
+    dataservices_fake_data,
+    role_configuration,
+    create_authz_token,
+):
+    with test_client() as client:
+        jwt = create_authz_token(None, "test@test.nl", [])
+        response = client.get(
+            "/?x=123282.6&y=487674.8&radius=1&datasets=fake",
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        json_response = json.loads(response.data)
+        assert len(json_response["features"]) == 1
+        assert g.token_subject == "test@test.nl"
+        assert (
+            db.dbconnection(
+                app.config["DSN_DATASERVICES_DATASETS"], set_user_role=True
+            )._active_user
+            == "test@test.nl_role"
+        )
+
+    # The user context must be cleaned up when the request context is popped
+    assert (
+        db.dbconnection(
+            app.config["DSN_DATASERVICES_DATASETS"], set_user_role=True
+        )._active_user
+        is None
+    )
+
+
+def test_employee_when_internal_jwt_but_role_does_not_exist(
+    active_user_context,
+    test_client,
+    dataservices_db,
+    dataservices_fake_data,
+    role_configuration,
+    create_authz_token,
+):
+    with test_client() as client:
+        jwt = create_authz_token(None, "test@amsterdam.nl", [])
+        response = client.get(
+            "/?x=123282.6&y=487674.8&radius=1&datasets=fake",
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        json_response = json.loads(response.data)
+        assert len(json_response["features"]) == 1
+        assert g.token_subject == "test@amsterdam.nl"
+        assert (
+            db.dbconnection(
+                app.config["DSN_DATASERVICES_DATASETS"], set_user_role=True
+            )._active_user
+            == "medewerker_role"
+        )

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -7,14 +7,14 @@ Jinja2==2.11.3
 MarkupSafe==1.1.1
 packaging==18.0
 pip-review==1.0
-psycopg2-binary==2.8.4
+psycopg2-binary==2.9.5
 pyparsing==2.4.6
 python-dateutil==2.8.1
 requests==2.23.0
 sentry-sdk==0.6.6
 six==1.12.0
 Werkzeug==0.16.1
-jwcrypto==0.7
+jwcrypto==1.4.2
 pytest==5.3.5
 PyYAML==5.4
 python-string-utils==1.0.0


### PR DESCRIPTION
Pass the end user context (if any) to the database so it can be included in audit logs and we can enforce the least privilege principle.

The general idea is: 

- The authenticate decorator stores user info on the Flask app context
- Datasources using the reference database are configured to include end user context on their connections
- Connections to databases determine whether to include user context based on appsettings and connection settings.
- The user context is "deactivated" when the request context is popped by iterating over the connection pool and rolling back active contexts.