### PR TITLE
Fix 50K type-errors per day error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ node {
                 file(credentialsId:"OS_CREDS", variable: "OS_CREDS"),
             ]) {
                 sh '''
-                    export OS_AUTH_TOKEN=$(curl -H "Content-Type: application/json" -s 'https://identity.stack.cloudvps.com/v2.0/tokens' -d @$OS_CREDS | python -c "import sys; import json; print(json.loads(sys.stdin.read())['access']['token']['id'])")
+                    export OS_AUTH_TOKEN=$(curl -H "Content-Type: application/json" -s 'https://identity.stack.cloudvps.com/v2.0/tokens' -d @$OS_CREDS | python3 -c "import sys; import json; print(json.loads(sys.stdin.read())['access']['token']['id'])")
                     .jenkins/runtests.sh
                 '''
                }

--- a/web/geosearch/datapunt_geosearch/base_config.py
+++ b/web/geosearch/datapunt_geosearch/base_config.py
@@ -10,6 +10,7 @@ CLOUD_ENV = os.getenv("CLOUD_ENV", "CLOUDVPS")
 
 db_connection_string = "postgresql://{username}:{password}@{host}:{port}/{db}"
 
+DSN_ADMIN_USER = ""  # needs an initial value, because is imported from elsewhere
 # On Azure we need a superuser to configure end user context in tests
 if CLOUD_ENV.lower() == "azure":
     DSN_ADMIN_USER = db_connection_string.format(

--- a/web/geosearch/datapunt_geosearch/blueprints/search.py
+++ b/web/geosearch/datapunt_geosearch/blueprints/search.py
@@ -284,9 +284,9 @@ def search_geo_atlas():
 
 
 # This should be the last (catchall) route/view combination
-@search.route("/<string:dataset>/", methods=["GET", "OPTIONS"])
 @authenticate
 @retry_on_psycopg2_error
+@search.route("/<string:dataset>/", methods=["GET", "OPTIONS"])
 def search_geo_genapi(dataset):
     """Performing a geo search for radius around a point using postgres.
 


### PR DESCRIPTION
Geosearch generates approx 50K on type errors per day. Seems to be be related with the order in which decorators are applied.