### PR TITLE
Bump Werkzeug, MarkupSafe

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -4,7 +4,7 @@ Flask==1.1.1
 Flask-Cors==3.0.9
 itsdangerous==1.1.0
 Jinja2==2.11.3
-MarkupSafe==1.1.1
+MarkupSafe==2.1.2
 packaging==18.0
 pip-review==1.0
 psycopg2-binary==2.9.5
@@ -13,7 +13,7 @@ python-dateutil==2.8.1
 requests==2.23.0
 sentry-sdk==0.6.6
 six==1.12.0
-Werkzeug==0.16.1
+Werkzeug==2.2.3
 jwcrypto==1.4.2
 pytest==5.3.5
 PyYAML==5.4

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,6 +1,6 @@
 blinker==1.4
 click>=7.0
-Flask==1.1.1
+Flask==2.2.3
 Flask-Cors==3.0.9
 itsdangerous==1.1.0
 Jinja2==3.1.2

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -3,7 +3,7 @@ click>=7.0
 Flask==1.1.1
 Flask-Cors==3.0.9
 itsdangerous==1.1.0
-Jinja2==2.11.3
+Jinja2==3.1.2
 MarkupSafe==2.1.2
 packaging==18.0
 pip-review==1.0

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -2,7 +2,7 @@ blinker==1.4
 click>=7.0
 Flask==2.2.3
 Flask-Cors==3.0.9
-itsdangerous==1.1.0
+itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.2
 packaging==18.0


### PR DESCRIPTION
Security update. Fixes [AB#72801](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/72801). Closes #68.