### PR TITLE
AB#78345 Add possibility to have extra field in the response.

### DIFF
--- a/web/geosearch/datapunt_geosearch/blueprints/engine.py
+++ b/web/geosearch/datapunt_geosearch/blueprints/engine.py
@@ -1,3 +1,4 @@
+from schematools.naming import to_snake_case
 import logging
 
 try:
@@ -50,6 +51,10 @@ def fetch_data(sourceClass, request_args, datasets):
 
     if request_args["limit"]:
         datasource.limit = request_args["limit"]
+
+    if field_names_in_query := request_args.get("_fields", "").split(","):
+        # We collect extra field_names that need to be in the resulting response
+        datasource.field_names_in_query = [to_snake_case(fn) for fn in field_names_in_query if fn]
 
     try:
         response = datasource.execute_queries(datasets=datasets)

--- a/web/geosearch/datapunt_geosearch/blueprints/search.py
+++ b/web/geosearch/datapunt_geosearch/blueprints/search.py
@@ -76,6 +76,7 @@ def search_everywhere():
         return jsonify(resp)
 
     request_args = dict(request.args)
+
     request_args.update(
         dict(
             x=x,
@@ -181,7 +182,13 @@ def search_in_datasets():
     if not known_dataset:
         return jsonify({"error": "Unknown item type"})
 
-    resp = ds.query(float(x), float(y), rd=rd, limit=limit, radius=radius)
+    resp = ds.query(
+        float(x),
+        float(y),
+        rd=rd,
+        limit=limit,
+        radius=radius,
+    )
     return jsonify(resp)
 
 

--- a/web/geosearch/datapunt_geosearch/registry.py
+++ b/web/geosearch/datapunt_geosearch/registry.py
@@ -112,6 +112,7 @@ class DatasetRegistry:
         temporal_dimension=None,
         crs=None,
         set_user_role=False,
+        dataset_field_names=None
     ):
         """
         Initialize dataset class and register it in registry based on row data
@@ -207,6 +208,7 @@ class DatasetRegistry:
                 },
                 "dsn_name": dsn_name,
                 "temporal_bounds": temporal_bounds,
+                "dataset_field_names": dataset_field_names,
                 "crs": crs,
                 "set_user_role": set_user_role,
             },
@@ -302,6 +304,7 @@ class DatasetRegistry:
             # TODO: Remove all code assuming that schema_data can be inconsistent
             crs = DEFAULT_CRS
             temporal_dimension = None
+            dataset_field_names = None
             if row["schema_data"]:
                 try:
                     # TODO: Remove schematools as a dependency or use a proper loader
@@ -315,6 +318,7 @@ class DatasetRegistry:
                     )
                     crs = dataset_table.main_geometry_field.crs
                     temporal_dimension = self._fetch_temporal_dimensions(dataset_table)
+                    dataset_field_names = [f.db_name for f in dataset_table.fields]
                 except SchemaObjectNotFound:
                     # We should be able to assume that the ams-schemas are
                     # internally consistent but there is code (tests) in this
@@ -344,6 +348,7 @@ class DatasetRegistry:
                 # Connections to the reference database must use role switching
                 # on Azure.
                 set_user_role=True,
+                dataset_field_names=dataset_field_names
             )
             if dataset is not None:
                 key = f"{row['dataset_name']}/{row['name']}"

--- a/web/geosearch/tests/conftest.py
+++ b/web/geosearch/tests/conftest.py
@@ -297,12 +297,14 @@ def dataservices_fake_data(flask_test_app):
           "name" varchar(100) NOT NULL,
           "begin_geldigheid" timestamp without time zone,
           "eind_geldigheid" timestamp without time zone,
+          "volgnummer" integer,
           "geometry" geometry(POINT, 28992));
         CREATE TABLE IF NOT EXISTS "fake_secret" (
           "id" serial NOT NULL PRIMARY KEY,
           "name" varchar(100) NOT NULL,
           "begin_geldigheid" timestamp without time zone,
           "eind_geldigheid" timestamp without time zone,
+          "volgnummer" integer,
           "geometry" geometry(POINT, 28992));
         """
         )
@@ -310,13 +312,15 @@ def dataservices_fake_data(flask_test_app):
     with dataservices_db_connection.cursor() as cursor:
         cursor.execute(
             """
-        INSERT INTO "fake_fake" (id, name, geometry) VALUES (
+        INSERT INTO "fake_fake" (id, name, volgnummer, geometry) VALUES (
           1,
           'test',
+          1,
           ST_GeomFromText('POINT(123282.6 487674.8)', 28992));
-        INSERT INTO "fake_secret" (id, name, geometry) VALUES (
+        INSERT INTO "fake_secret" (id, name, volgnummer, geometry) VALUES (
           1,
           'secret test',
+          1,
           ST_GeomFromText('POINT(123282.6 487674.8)', 28992));
         """
         )

--- a/web/geosearch/tests/test_search_everywhere.py
+++ b/web/geosearch/tests/test_search_everywhere.py
@@ -71,6 +71,67 @@ class SearchEverywhereTestCase(unittest.TestCase):
             self.assertEqual(json_response["type"], "FeatureCollection")
             self.assertEqual(len(json_response["features"]), 1)
 
+    @pytest.mark.usefixtures("dataservices_fake_data")
+    def test_search_in_dataservices_requesting_extra_fields_in_response(self):
+        """Prove that extra fields that are requested for the response, are showing up."""
+        # Force registry to reload dataservices datasources
+        registry._datasets_initialized = None
+
+        with app.test_client() as client:
+            response = client.get(
+                "/?x=123282.6&y=487674.8&radius=1&datasets=fake/fake_public&_fields=volgnummer"
+            )
+            json_response = json.loads(response.data)
+            self.assertEqual(
+                json_response["features"][0]["properties"]["volgnummer"], 1
+            )
+
+    @pytest.mark.usefixtures("dataservices_fake_data")
+    def test_search_in_dataservices_non_existing_extra_fields_in_response(self):
+        """Prove that non existing fields that are requested for the response,
+        are not a problem.
+        """
+        # Force registry to reload dataservices datasources
+        registry._datasets_initialized = None
+
+        with app.test_client() as client:
+            response = client.get(
+                "/?x=123282.6&y=487674.8&radius=1&datasets=fake/fake_public&_fields=nonExisting"
+            )
+            json_response = json.loads(response.data)
+            self.assertEqual(json_response["type"], "FeatureCollection")
+            self.assertEqual(len(json_response["features"]), 1)
+
+    # @pytest.mark.usefixtures("dataservices_fake_data")
+    @pytest.mark.usefixtures("dataservices_db")
+    def test_search_in_dataservices_generic_non_existing_extra_fields_in_response(self):
+        """Prove that non existing fields that are requested for the generic search endpoint
+        are not a problem.
+        """
+        # Force registry to reload dataservices datasources
+        registry._datasets_initialized = None
+
+        with app.test_client() as client:
+            response = client.get("/?x=123282.6&y=487674.8&radius=100&_fields=nonExisting")
+            json_response = json.loads(response.data)
+            self.assertEqual(json_response["type"], "FeatureCollection")
+            self.assertEqual(len(json_response["features"]), 2)
+
+    @pytest.mark.usefixtures("dataservices_fake_data")
+    def test_search_in_dataservices_requesting_camelcased_fields_in_response(self):
+        """Prove that extra fields that are camelcased are returned properly."""
+        # Force registry to reload dataservices datasources
+        registry._datasets_initialized = None
+
+        with app.test_client() as client:
+            response = client.get(
+                "/?x=123282.6&y=487674.8&radius=1&datasets=fake/fake_public&_fields=eindGeldigheid"
+            )
+            json_response = json.loads(response.data)
+            self.assertEqual(
+                json_response["features"][0]["properties"]["eindGeldigheid"], None
+            )
+
     @pytest.mark.usefixtures("dataservices_fake_temporal_data_creator")
     @pytest.mark.usefixtures("dataservices_fake_data")
     def test_search_in_dataservices_using_temporal_data(self):


### PR DESCRIPTION
NB. This only works for amsterdam schema based datasets, because in that case we have field information available.

Normally, geosearch returns a fixed set a fields (with some variation per search backend). However, in some situations it can make querying much more efficient if extra fields can be returned immediately, because no round trips to additional APIs is needed.

The DSO-API standard has been followed, where a `_fields` param can be added to the requesting querystring that holds a comma-separated set of fields (snake_cased or camelCased).

If those fieldnames are matching with the available fields on the datasettable, the response will include those fields and their values.

Because we are only handling amsterdam schema based datasets, the fields will we be camelcased in the output.