### PR TITLE
Fix extra `_fields` feature to work with more datasets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,3 +50,4 @@ services:
         - TEST_SETTINGS_MODULE=datapunt_geosearch.test_config
         - LOG_LEVEL=INFO
         - DATABASE_SET_ROLE=
+        - SCHEMA_URL=https://acc.schemas.data.amsterdam.nl/datasets

--- a/web/geosearch/datapunt_geosearch/datasource.py
+++ b/web/geosearch/datapunt_geosearch/datasource.py
@@ -63,6 +63,14 @@ class DataSourceBase:
 
     @property
     def extra_field_names(self):
+        """ Return the extra fields in the geosearch output.
+        
+        The fieldnames that are possible because of the fields in de dataset
+        are configured in the `dataset_field_names` attribute on the class.
+        The `field_names_in_query` are from the `_fields` query parameter
+        in the request to the geosearch.
+        Those are checked against `dataset_field_names`.
+        """
         return set(self.field_names_in_query or []) & set(
             self.dataset_field_names or []
         )
@@ -167,6 +175,7 @@ class DataSourceBase:
         Datasource as psycopg2 Identifiers and SQL"""
 
         field_names = self.fields.split(",") + list(self.extra_field_names)
+
         return dict(
             fields=sql.SQL(", ").join(
                 map(sql.SQL, field_names)


### PR DESCRIPTION
The `_fields` option was not working for all datasets. For names with underscores, the dataset query class was not initialized propertly. Because the tablename in `datasets_datasettable` is snakecased, but the actual table id is camelcased.

 And for schemas that are split up over multiple files,
the query class was also not initialized. So, the schematools class loader needed to be introduced to fix this problem.