### PR TITLE
Update vulnerable dependencies

### DIFF
--- a/web/requirements_dev.in
+++ b/web/requirements_dev.in
@@ -7,4 +7,4 @@ pre-commit==2.20.0
 bandit[toml]==1.7.5
 # The packages below are indirect dependencies that have minimum versions specified
 # to avoid vulnerabilities
-gitpython>=3.1.32
+gitpython>=3.1.35


### PR DESCRIPTION
GitPython to >= 3.1.35

Upgraded the following indirect dependencies:
bandit to 1.7.5
certifi to 2023.7.22
cryptography to 41.0.3