### PR TITLE
AB#104486 Use `identificatie` as the id-field for temporal tables

### DIFF
--- a/web/geosearch/tests/test_search_everywhere.py
+++ b/web/geosearch/tests/test_search_everywhere.py
@@ -153,3 +153,6 @@ class SearchEverywhereTestCase(unittest.TestCase):
                     self.assertEqual(json_response["type"], "FeatureCollection")
                     self.assertEqual(len(json_response["features"]), count)
                     self.assertIn("path/fake", json_response["features"][0]["properties"]["uri"])
+                    # Check that `identificatie` is used, and not the raw `id` field
+                    for feature in json_response["features"]:
+                        self.assertFalse("." in feature["properties"]["id"])


### PR DESCRIPTION
Temporal tables have a internal `id` that usually is the concatenation of `identificatie`.`volgnummer`. However, users of geosearch are not interested in this raw internal `id`.  They want to know the `identificatie` field. This PR exposes that field, instead of the raw `id` field.