### PR TITLE
Changes needed to make logging to Azure LAWS work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ NB. See above about the needed PIP_CONSTRAINT.
 The local geosearch application can be started with `python web/geosearch/wsgi.py` 
 (with an active venv).
 
+To run the geosearch application against the Azure postgreSQL instance
+define the following environment variables:
+
+    export DATASERVICES_PW_LOCATION
+    export DATASERVICES_DB_DATABASE_OVERRIDE
+    export DATASERVICES_DB_HOST_OVERRIDE
+    export DATASERVICES_DB_USER_OVERRIDE
+
+The DATASERVICES_PW_LOCATION should point to a local file that contains
+a valid postgreSQL user token.
+
 
 ## Container setup
 

--- a/web/geosearch/datapunt_geosearch/__init__.py
+++ b/web/geosearch/datapunt_geosearch/__init__.py
@@ -1,13 +1,19 @@
 # Packages
+import logging
 import os
 
-import sentry_sdk
-from flask import Flask
-from flask_cors import CORS
-from sentry_sdk.integrations.flask import FlaskIntegration
+from azure.monitor.opentelemetry import configure_azure_monitor
 
 from datapunt_geosearch.blueprints import health, search
 from datapunt_geosearch.db import connection_cache
+
+# Configure OpenTelemetry to use Azure Monitor with the
+# APPLICATIONINSIGHTS_CONNECTION_STRING environment variable.
+APPLICATIONINSIGHTS_CONNECTION_STRING = os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING")
+if APPLICATIONINSIGHTS_CONNECTION_STRING is not None:
+    configure_azure_monitor(logger_name="root")
+    logger = logging.getLogger("root")
+    logger.warning("OpenTelemetry has been enabled")
 
 
 def deactivate_user_context(e):
@@ -18,11 +24,11 @@ def deactivate_user_context(e):
 
 
 def create_app(import_path: str = "datapunt_geosearch.config"):
-    sentry_dsn = os.getenv("SENTRY_DSN")
-    if sentry_dsn:
-        sentry_sdk.init(dsn=sentry_dsn, environment="geosearch", integrations=[FlaskIntegration()])
 
-    app = Flask("geosearch")
+    import flask
+    from flask_cors import CORS
+
+    app = flask.Flask("geosearch")
     CORS(app)
 
     app.config.from_object(import_path)

--- a/web/geosearch/datapunt_geosearch/base_config.py
+++ b/web/geosearch/datapunt_geosearch/base_config.py
@@ -1,19 +1,9 @@
+import logging
 import os
-from logging.config import dictConfig
 from pathlib import Path
 from typing import Dict
 
-from azure.monitor.opentelemetry import configure_azure_monitor
-from opentelemetry import trace
-
 from datapunt_geosearch.authz import get_keyset
-
-# Configure OpenTelemetry to use Azure Monitor with the
-# APPLICATIONINSIGHTS_CONNECTION_STRING environment variable.
-APPLICATIONINSIGHTS_CONNECTION_STRING = os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING")
-if APPLICATIONINSIGHTS_CONNECTION_STRING is not None:
-    configure_azure_monitor()
-
 
 DATABASE_SET_ROLE = os.getenv("DATABASE_SET_ROLE", False)
 CLOUD_ENV = os.getenv("CLOUD_ENV", "CLOUDVPS")
@@ -101,22 +91,3 @@ JWKS_SIGNING_ALGORITHMS = [
 ]
 
 JW_KEYSET = get_keyset(jwks=JWKS, jwks_url=JWKS_URL)
-
-dictConfig(
-    {
-        "version": 1,
-        "formatters": {
-            "default": {
-                "format": "[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
-            }
-        },
-        "handlers": {
-            "wsgi": {
-                "class": "logging.StreamHandler",
-                "stream": "ext://flask.logging.wsgi_errors_stream",
-                "formatter": "default",
-            }
-        },
-        "root": {"level": os.getenv("LOG_LEVEL", "INFO"), "handlers": ["wsgi"]},
-    }
-)

--- a/web/geosearch/datapunt_geosearch/blueprints/health.py
+++ b/web/geosearch/datapunt_geosearch/blueprints/health.py
@@ -1,5 +1,6 @@
 # Packages
 import json
+import logging
 import time
 
 from flask import Blueprint, Response, current_app
@@ -7,6 +8,8 @@ from flask import Blueprint, Response, current_app
 from datapunt_geosearch.registry import registry
 
 health = Blueprint("health", __name__)
+
+logger = logging.getLogger(__name__)
 
 
 @health.route("/status", methods=["GET", "HEAD", "OPTIONS"])
@@ -33,6 +36,7 @@ def force_refresh():
 def search_list():
     """Execute test query against datasources"""
 
+    logger.warning("Accessing health endpoint. New and shiny.")
     # Use one of the ref db. datasources
     gebieden_buurten_ds_cls = registry.get_by_name("gebieden/buurten")
     x, y, response_text = 120993, 485919, []


### PR DESCRIPTION
It turns out that the call to `configure_azure_monitor` is sufficient. This will also instrument flask logging.

However, some caveats do apply:

- The logger that needs to be configured is the `root` logger, so, all other loggers that are being used will also work (presumable, because all logging eventually ends up in the root logger).

- flask needs to be imported after the call to `configure_azure_monitor` (not sure if this is really neccessary, but found this in an official Microsoft reply)

- Do not use `from flask import Flask`, but `import flask` (also from M$ reply)

Furthermore, info has been added to the readme about running geosearch locally against a postgreSQL server on Azure.