### PR TITLE
Update python version in precommit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,4 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
     - uses: pre-commit/action@v2.0.3


### PR DESCRIPTION
Precommit hooks were failing because of a mismatch in the specified python versions