### PR TITLE
Fix versioned tables

### DIFF
--- a/web/geosearch/datapunt_geosearch/registry.py
+++ b/web/geosearch/datapunt_geosearch/registry.py
@@ -272,10 +272,16 @@ class DatasetRegistry:
         d.schema_data,
         d.auth as dataset_authorization,
         dt.auth as datasettable_authorization
-    FROM datasets_datasettable dt
-    LEFT JOIN datasets_dataset d
-      ON dt.dataset_id = d.id
-    WHERE d.enable_api = true AND dt.enable_geosearch = true
+    FROM datasets_dataset d
+    LEFT JOIN datasets_datasetversion dv
+      ON d.id = dv.dataset_id
+    LEFT JOIN datasets_datasettable_dataset_versions dtv
+      ON dv.id = dtv.datasetversion_id
+    LEFT JOIN datasets_datasettable dt
+      ON dt.id = dtv.datasettable_id
+    WHERE d.default_version = dv.version
+      AND d.enable_api = true AND dt.enable_geosearch = true
+      AND d.default_version = dv.version
       AND geometry_field_type is not null
         """
         datasets = dict()


### PR DESCRIPTION
Geosearch is using a query on the datasets tables to fill it's registry. This could possibly fail on the versioned tables, since there was no logic for this scenario. A quick fix has been implemented to always get the default version.

Tests were also failing because of the order in which records were returned from the database. As a quick fix the order of inserts is changed, but we need to look into a permanent solution or refactor to solve the underlying issues.