### PR TITLE
Fix dependabot directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/src" # Location of package manifests
+    directory: "/web" # Location of package manifests
     schedule:
       interval: "weekly"
     groups:
@@ -16,6 +16,6 @@ updates:
         - "minor"
         - "patch"
   - package-ecosystem: "docker" # See documentation for possible values
-    directory: "/src" # Location of package manifests
+    directory: "/web" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
After the previous PR #143 this turned out to be broken.

https://github.com/Amsterdam/geosearch/actions/runs/17918884225/job/50948264609